### PR TITLE
Make openSUSE images more openSUSE-y

### DIFF
--- a/src/bci_build/package.py
+++ b/src/bci_build/package.py
@@ -262,8 +262,8 @@ class BaseContainerImage(abc.ABC):
     #: for bash and not for a different shell.
     config_sh_interpreter: str = "/bin/bash"
 
-    #: The maintainer of this image, defaults to SUSE
-    maintainer: str = "SUSE LLC (https://www.suse.com/)"
+    #: The maintainer of this image, defaults to SUSE/openSUSE
+    maintainer: Optional[str] = None
 
     #: Additional files that belong into this container-package.
     #: The key is the filename, the values are the file contents.
@@ -293,14 +293,6 @@ class BaseContainerImage(abc.ABC):
     #: or kiwi build description file.
     license: str = "MIT"
 
-    #: The default url that is put into the ``org.opencontainers.image.url``
-    #: label
-    URL: ClassVar[str] = "https://www.suse.com/products/server/"
-
-    #: The vendor that is put into the ``org.opencontainers.image.vendor``
-    #: label
-    VENDOR: ClassVar[str] = "SUSE LLC"
-
     #: The support level for this image, defaults to :py:attr:`SupportLevel.TECHPREVIEW`
     support_level: SupportLevel = SupportLevel.TECHPREVIEW
 
@@ -316,6 +308,16 @@ class BaseContainerImage(abc.ABC):
             self.build_recipe_type = (
                 BuildType.KIWI if self.os_version == OsVersion.SP3 else BuildType.DOCKER
             )
+        if self.maintainer is None:
+            self.maintainer = (
+                "openSUSE (https://www.opensuse.org/)"
+                if self.is_opensuse
+                else "SUSE LLC (https://www.suse.com/)"
+            )
+
+    @property
+    def is_opensuse(self) -> bool:
+        return self.os_version == OsVersion.TUMBLEWEED
 
     @property
     @abc.abstractmethod
@@ -353,6 +355,36 @@ class BaseContainerImage(abc.ABC):
             return ReleaseStage.RELEASED
 
         return ReleaseStage.BETA
+
+    @property
+    def url(self) -> str:
+        """The default url that is put into the
+        ``org.opencontainers.image.url`` label
+
+        """
+        if self.is_opensuse:
+            return "https://www.opensuse.org/"
+
+        return "https://www.suse.com/products/server/"
+
+    @property
+    def vendor(self) -> str:
+        """The vendor that is put into the ``org.opencontainers.image.vendor``
+        label
+
+        """
+        if self.is_opensuse:
+            return "openSUSE Project"
+
+        return "SUSE LLC"
+
+    @property
+    def registry(self) -> str:
+        """The registry where the image is available on."""
+        if self.is_opensuse:
+            return "registry.opensuse.org"
+
+        return "registry.suse.com"
 
     @property
     def dockerfile_custom_end(self) -> str:
@@ -674,7 +706,7 @@ exit 0
     def reference(self) -> str:
         """The primary URL via which this image can be pulled. It is used to set the
         ``org.opensuse.reference`` label and defaults to
-        ``registry.suse.com/{self.build_tags[0]}``.
+        ``{self.registry}/{self.build_tags[0]}``.
 
         """
         pass
@@ -689,10 +721,16 @@ exit 0
         :py:attr:`BaseContainerImage.pretty_name` to generate a description.
 
         """
-        return (
-            self.custom_description
-            or f"{self.pretty_name} based on the SLE Base Container Image."
-        )
+        if self.custom_description:
+            return self.custom_description
+
+        if self.is_opensuse:
+            return (
+                f"{self.pretty_name} based on the openSUSE Tumbleweed "
+                "Base Container Image"
+            )
+
+        return f"{self.pretty_name} based on the SLE Base Container Image."
 
     @property
     def title(self) -> str:
@@ -703,6 +741,9 @@ exit 0
         follows: ``"SLE BCI {self.pretty_name} Container Image"``.
 
         """
+        if self.is_opensuse:
+            return f"openSUSE Tumbleweed BCI {self.pretty_name} Container Image"
+
         return f"SLE BCI {self.pretty_name} Container Image"
 
     @property
@@ -748,7 +789,7 @@ exit 0
 
         """
         return (
-            "com.suse."
+            ("org.opensuse." if self.is_opensuse else "com.suse.")
             + (
                 {ImageType.SLE_BCI: "bci", ImageType.APPLICATION: "application"}[
                     self.image_type
@@ -891,7 +932,7 @@ class LanguageStackContainer(BaseContainerImage):
 
     @property
     def reference(self) -> str:
-        return f"registry.suse.com/{self._registry_prefix}/{self.name}:{self.version_label}-%RELEASE%"
+        return f"{self.registry}/{self._registry_prefix}/{self.name}:{self.version_label}-%RELEASE%"
 
 
 @dataclass
@@ -941,7 +982,7 @@ class OsContainer(BaseContainerImage):
 
     @property
     def reference(self) -> str:
-        return f"registry.suse.com/bci/bci-{self.name}:{self.version_label}"
+        return f"{self.registry}/bci/bci-{self.name}:{self.version_label}"
 
 
 def _generate_disk_size_constraints(size_gb: int) -> str:

--- a/src/bci_build/package.py
+++ b/src/bci_build/package.py
@@ -1795,7 +1795,7 @@ STOPSIGNAL SIGQUIT
 _RUST_GCC_PATH = "/usr/local/bin/gcc"
 
 # ensure that the **latest** rust version is the last one!
-_RUST_VERSIONS = ["1.61", "1.62", "1.63", "1.64"]
+_RUST_VERSIONS = ["1.62", "1.63", "1.64"]
 
 RUST_CONTAINERS = [
     LanguageStackContainer(

--- a/src/bci_build/package.py
+++ b/src/bci_build/package.py
@@ -1269,11 +1269,12 @@ GOLANG_IMAGES = [
 ]
 
 
-def _get_node_kwargs(ver: Literal[14, 16], os_version: OsVersion):
+def _get_node_kwargs(ver: Literal[14, 16, 18, 19], os_version: OsVersion):
     return {
         "name": "nodejs",
         "os_version": os_version,
-        "is_latest": ver == 16 and os_version in CAN_BE_LATEST_OS_VERSION,
+        "is_latest": (ver == 16 and os_version == OsVersion.SP4)
+        or (ver == 19 and os_version == OsVersion.TUMBLEWEED),
         "package_name": f"nodejs-{ver}"
         + ("-image" if os_version != OsVersion.SP3 else ""),
         "custom_description": f"Node.js {ver} development environment based on the SLE Base Container Image.",
@@ -1299,7 +1300,8 @@ NODE_CONTAINERS = [
     LanguageStackContainer(
         **_get_node_kwargs(ver, os_version), support_level=SupportLevel.L3
     )
-    for ver, os_version in product((14, 16), ALL_OS_VERSIONS)
+    for ver, os_version in list(product((14, 16), (OsVersion.SP3, OsVersion.SP4)))
+    + [(18, OsVersion.TUMBLEWEED), (19, OsVersion.TUMBLEWEED)]
 ]
 
 
@@ -2068,7 +2070,6 @@ ALL_CONTAINER_IMAGE_NAMES: Dict[str, BaseContainerImage] = {
         *BUSYBOX_CONTAINERS,
     )
 }
-ALL_CONTAINER_IMAGE_NAMES.pop("nodejs-14-Tumbleweed")
 ALL_CONTAINER_IMAGE_NAMES.pop("golang-1.19-sp3")
 
 SORTED_CONTAINER_IMAGE_NAMES = sorted(

--- a/src/bci_build/package.py
+++ b/src/bci_build/package.py
@@ -1844,8 +1844,8 @@ MICRO_CONTAINERS = [
                 # ca-certificates-mozilla-prebuilt requires /bin/cp, which is otherwise not resolved…
                 "coreutils",
                 "distribution-release",
-                "skelcd-EULA-bci",
             )
+            + (() if os_version == OsVersion.TUMBLEWEED else ("skelcd-EULA-bci",))
         ],
         # intentionally empty
         config_sh_script="""

--- a/src/bci_build/templates.py
+++ b/src/bci_build/templates.py
@@ -21,15 +21,15 @@ MAINTAINER {{ image.maintainer }}
 LABEL org.opencontainers.image.title="{{ image.title }}"
 LABEL org.opencontainers.image.description="{{ image.description }}"
 LABEL org.opencontainers.image.version="{{ image.version_label }}"
-LABEL org.opencontainers.image.url="{{ image.URL }}"
+LABEL org.opencontainers.image.url="{{ image.url }}"
 LABEL org.opencontainers.image.created="%BUILDTIME%"
-LABEL org.opencontainers.image.vendor="{{ image.VENDOR }}"
+LABEL org.opencontainers.image.vendor="{{ image.vendor }}"
 LABEL org.opensuse.reference="{{ image.reference }}"
 LABEL org.openbuildservice.disturl="%DISTURL%"
-LABEL com.suse.supportlevel="{{ image.support_level }}"
+{% if not image.is_opensuse %}LABEL com.suse.supportlevel="{{ image.support_level }}"
 LABEL com.suse.eula="sle-bci"
 LABEL com.suse.lifecycle-url="https://www.suse.com/lifecycle"
-LABEL com.suse.image-type="{{ image.image_type }}"
+LABEL com.suse.image-type="{{ image.image_type }}"{% endif %}
 LABEL com.suse.release-stage="{{ image.release_stage }}"
 # endlabelprefix
 {%- if image.extra_label_lines %}{{ image.extra_label_lines }}{% endif %}
@@ -54,7 +54,7 @@ KIWI_TEMPLATE = jinja2.Template(
 
 <image schemaversion="6.5" name="{{ image.uid }}-image" xmlns:suse_label_helper="com.suse.label_helper">
   <description type="system">
-    <author>{{ image.VENDOR }}</author>
+    <author>{{ image.vendor }}</author>
     <contact>https://www.suse.com/</contact>
     <specification>{{ image.title }}</specification>
   </description>
@@ -72,15 +72,15 @@ KIWI_TEMPLATE = jinja2.Template(
             <label name="org.opencontainers.image.description" value="{{ image.description }}"/>
             <label name="org.opencontainers.image.version" value="{{ image.version_label }}"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
-            <label name="org.opencontainers.image.vendor" value="{{ image.VENDOR }}"/>
-            <label name="org.opencontainers.image.url" value="{{ image.URL }}"/>
+            <label name="org.opencontainers.image.vendor" value="{{ image.vendor }}"/>
+            <label name="org.opencontainers.image.url" value="{{ image.url }}"/>
             <label name="org.opensuse.reference" value="{{ image.reference }}"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
-            <label name="com.suse.supportlevel" value="{{ image.support_level }}"/>
-            <label name="com.suse.image-type" value="{{ image.image_type }}"/>
+{% if not image.is_opensuse %}            <label name="com.suse.supportlevel" value="{{ image.support_level }}"/>
             <label name="com.suse.eula" value="sle-bci"/>
-            <label name="com.suse.release-stage" value="{{ image.release_stage }}"/>
             <label name="com.suse.lifecycle-url" value="https://www.suse.com/lifecycle"/>
+            <label name="com.suse.image-type" value="{{ image.image_type }}"/>{% endif %}
+            <label name="com.suse.release-stage" value="{{ image.release_stage }}"/>
 {{- image.extra_label_xml_lines }}
           </suse_label_helper:add_prefix>
         </labels>

--- a/src/bci_build/templates.py
+++ b/src/bci_build/templates.py
@@ -77,10 +77,10 @@ KIWI_TEMPLATE = jinja2.Template(
             <label name="org.opensuse.reference" value="{{ image.reference }}"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
 {% if not image.is_opensuse %}            <label name="com.suse.supportlevel" value="{{ image.support_level }}"/>
-            <label name="com.suse.eula" value="sle-bci"/>
-            <label name="com.suse.lifecycle-url" value="https://www.suse.com/lifecycle"/>
-            <label name="com.suse.image-type" value="{{ image.image_type }}"/>{% endif %}
-            <label name="com.suse.release-stage" value="{{ image.release_stage }}"/>
+            <label name="com.suse.image-type" value="{{ image.image_type }}"/>
+            <label name="com.suse.eula" value="sle-bci"/>{% endif %}
+            <label name="com.suse.release-stage" value="{{ image.release_stage }}"/>{% if not image.is_opensuse %}
+            <label name="com.suse.lifecycle-url" value="https://www.suse.com/lifecycle"/>{% endif %}
 {{- image.extra_label_xml_lines }}
           </suse_label_helper:add_prefix>
         </labels>

--- a/src/staging/build_result.py
+++ b/src/staging/build_result.py
@@ -199,7 +199,12 @@ def render_as_markdown(
     except ValueError:
         build_res = "Still building 🛻"
 
-    res = "\n" + build_res + "\n"
+    res = f"""
+{build_res}
+<details>
+<summary>Build Results</summary>
+
+"""
 
     for repo_res in results:
         res += (
@@ -237,4 +242,11 @@ package name | status {'' if no_detail else '| detail '}| build log
                 )
         res += "\n"
 
-    return res + "\n" + build_res + "\n"
+    return (
+        res
+        + f"""
+</details>
+
+{build_res}
+"""
+    )

--- a/tests/test_build_results.py
+++ b/tests/test_build_results.py
@@ -223,6 +223,9 @@ def test_is_build_failed(build_res: list[RepositoryBuildResult], is_failed: bool
             ],
             """
 Build succeeded ✅
+<details>
+<summary>Build Results</summary>
+
 Repository `containerfile` in [home:defolos:BCI:Staging:SLE-15-SP3:sle15-sp3-NBdNL](https://build.opensuse.org/project/show/home:defolos:BCI:Staging:SLE-15-SP3:sle15-sp3-NBdNL) for `aarch64`: current state: published
 Build results:
 package name | status | build log
@@ -230,6 +233,8 @@ package name | status | build log
 init | ✅ succeeded | [live log](https://build.opensuse.org/package/live_build_log/home:defolos:BCI:Staging:SLE-15-SP3:sle15-sp3-NBdNL/init/containerfile/aarch64)
 micro | ⛔ excluded | [live log](https://build.opensuse.org/package/live_build_log/home:defolos:BCI:Staging:SLE-15-SP3:sle15-sp3-NBdNL/micro/containerfile/aarch64)
 
+
+</details>
 
 Build succeeded ✅
 """,
@@ -255,6 +260,9 @@ Build succeeded ✅
             ],
             """
 Still building 🛻
+<details>
+<summary>Build Results</summary>
+
 Repository `containerfile` in [home:defolos:BCI:Staging:SLE-15-SP3:sle15-sp3-NBdNL](https://build.opensuse.org/project/show/home:defolos:BCI:Staging:SLE-15-SP3:sle15-sp3-NBdNL) for `aarch64`: current state: building (repository is **dirty**)
 Build results:
 package name | status | detail | build log
@@ -262,6 +270,8 @@ package name | status | detail | build log
 init | ❌ failed | | [live log](https://build.opensuse.org/package/live_build_log/home:defolos:BCI:Staging:SLE-15-SP3:sle15-sp3-NBdNL/init/containerfile/aarch64)
 micro | 🚫 unresolvable | Nothing provides gcc | [live log](https://build.opensuse.org/package/live_build_log/home:defolos:BCI:Staging:SLE-15-SP3:sle15-sp3-NBdNL/micro/containerfile/aarch64)
 
+
+</details>
 
 Still building 🛻
 """,
@@ -286,6 +296,9 @@ Still building 🛻
             ],
             """
 Build failed ❌
+<details>
+<summary>Build Results</summary>
+
 Repository `containerfile` in [home:defolos:BCI:Staging:SLE-15-SP3:sle15-sp3-NBdNL](https://build.opensuse.org/project/show/home:defolos:BCI:Staging:SLE-15-SP3:sle15-sp3-NBdNL) for `aarch64`: current state: published
 Build results:
 package name | status | detail | build log
@@ -293,6 +306,8 @@ package name | status | detail | build log
 init | ❌ failed | | [live log](https://build.opensuse.org/package/live_build_log/home:defolos:BCI:Staging:SLE-15-SP3:sle15-sp3-NBdNL/init/containerfile/aarch64)
 micro | 🚫 unresolvable | Nothing provides rust | [live log](https://build.opensuse.org/package/live_build_log/home:defolos:BCI:Staging:SLE-15-SP3:sle15-sp3-NBdNL/micro/containerfile/aarch64)
 
+
+</details>
 
 Build failed ❌
 """,


### PR DESCRIPTION
Replace SLE references such as registry.suse.com and SLE specific info
with openSUSE equivalents.

- [ ] There are some SLE specific references remaining, like some custom descriptions
- [ ] Not tested much yet, only some images looked at manually
- [ ] Omit `com.suse.release-stage` on TW as well? Might still be useful info.
- [x] Due to the conditions in the templates there are some empty lines/gaps now. Those are purely cosmetic and a bit annoying to avoid in the template code. Should those be addressed?