### PR TITLE
Add main python package to python containers

### DIFF
--- a/src/bci_build/package.py
+++ b/src/bci_build/package.py
@@ -1108,7 +1108,7 @@ def _get_python_kwargs(
         "version": py3_ver,
         "additional_versions": ["3"],
         "env": {"PYTHON_VERSION": py3_ver_replacement, "PIP_VERSION": pip3_replacement},
-        "package_list": [f"{py3}-devel", pip3, "curl", "git-core"]
+        "package_list": [f"{py3}-devel", py3, pip3, "curl", "git-core"]
         + (
             [f"{py3}-wheel"]
             if is_system_py or os_version == OsVersion.TUMBLEWEED


### PR DESCRIPTION
Otherwise certain modules like sqlite3 are missing.
This fixes: https://bugzilla.suse.com/show_bug.cgi?id=1205850