### PR TITLE
pcp: handle non-existing wicked gracefully

### DIFF
--- a/src/bci_build/package.py
+++ b/src/bci_build/package.py
@@ -2069,7 +2069,7 @@ COPY pmproxy.conf.template 10-host_mount.conf.template /usr/share/container-scri
 COPY pmcd pmlogger /etc/sysconfig/
 
 # This can be removed after the pcp dependency on sysconfig is removed
-{DOCKERFILE_RUN} systemctl disable wicked wickedd
+{DOCKERFILE_RUN} systemctl disable wicked wickedd || :
 
 HEALTHCHECK --start-period=30s --timeout=20s --interval=10s --retries=3 \
     CMD /usr/local/bin/healthcheck


### PR DESCRIPTION
This is needed to fix the build of the tumbleweed container, while it is still needed on older distributions