### PR TITLE
More 🦆-tape around BuildVersion

### DIFF
--- a/src/bci_build/package.py
+++ b/src/bci_build/package.py
@@ -1026,8 +1026,17 @@ class LanguageStackContainer(BaseContainerImage):
             # for non PEP440 versions, we'll get an exception and just return
             # the parent's classes build_version
             try:
-                version.parse(str(self.version))
-                return f"{build_ver}.{self.version}"
+                # more fun!
+                # if the language stack version has a higher version that
+                # build_version, then we must put the stack version first and
+                # append the build version, so that it will order as newer than
+                # previously published images without buildversion
+                stack_version = version.parse(str(self.version))
+                build_version = version.parse(build_ver)
+                if stack_version >= build_version:
+                    return f"{self.version}.{build_ver}"
+                else:
+                    return f"{build_ver}.{self.version}"
             except version.InvalidVersion:
                 return build_ver
         return None

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -12,7 +12,7 @@ from bci_build.templates import DOCKERFILE_TEMPLATE
             """# SPDX-License-Identifier: MIT
 #!BuildTag: bci/test:28
 #!BuildTag: bci/test:28-%RELEASE%
-#!BuildVersion: 15.4.28
+#!BuildVersion: 28.15.4
 FROM suse/sle15:15.4
 
 MAINTAINER SUSE LLC (https://www.suse.com/)
@@ -91,7 +91,7 @@ RUN zypper -n in --no-recommends gcc emacs; zypper -n clean; rm -rf /var/log/*
             """# SPDX-License-Identifier: MIT
 #!BuildTag: bci/test:28
 #!BuildTag: bci/test:28-%RELEASE%
-#!BuildVersion: 15.4.28
+#!BuildVersion: 28.15.4
 FROM suse/sle15:15.4
 
 MAINTAINER SUSE LLC (https://www.suse.com/)
@@ -137,7 +137,7 @@ RUN zypper -n in --no-recommends gcc emacs; zypper -n clean; rm -rf /var/log/*
 #!BuildTag: bci/emacs:28
 #!BuildTag: bci/emacs:28-%RELEASE%
 #!BuildTag: bci/emacs:latest
-#!BuildVersion: 15.4.28.2
+#!BuildVersion: 28.2.15.4
 FROM suse/base:18
 
 MAINTAINER invalid@suse.com
@@ -197,3 +197,25 @@ RUN emacs -Q --batch""",
 )
 def test_dockerfile_template(dockerfile: str, image: LanguageStackContainer):
     assert DOCKERFILE_TEMPLATE.render(DOCKERFILE_RUN="RUN", image=image) == dockerfile
+
+
+_kwargs = {
+    "name": "test",
+    "pretty_name": "Test",
+    "os_version": OsVersion.SP4,
+    "package_name": "test",
+    "package_list": ["foo"],
+}
+
+
+@pytest.mark.parametrize(
+    "image,build_version",
+    [
+        (LanguageStackContainer(**_kwargs, version="16"), "16.15.4"),
+        (LanguageStackContainer(**_kwargs, version="14.6"), "15.4.14.6"),
+    ],
+)
+def test_build_version(image: LanguageStackContainer, build_version: str):
+    assert f"#!BuildVersion: {build_version}" in DOCKERFILE_TEMPLATE.render(
+        DOCKERFILE_RUN="RUN", image=image
+    )


### PR DESCRIPTION
We have to swap out the version and buildversion for language stack containers where the version is higher than buildversion. Otherwise images without buildversion that are older will order as newer than images that are actually newer, but have the buildversion set.