### PR TITLE
pcp: fix pmlogger_daily not purging old archives

### DIFF
--- a/src/bci_build/pcp/container-entrypoint
+++ b/src/bci_build/pcp/container-entrypoint
@@ -35,5 +35,7 @@ touch /etc/pcp/pmieconf/dm/metadata_high_util
 mkdir -p /etc/pcp/pmieconf/zeroconf
 touch /etc/pcp/pmieconf/zeroconf/all_threads
 
+chown pcp:pcp /var/log/pcp/pmlogger
+
 echo Starting systemd...
 exec "$@"


### PR DESCRIPTION
The pmlogger_daily.service was failing silently because it runs as user pcp which did not have permissions on `/var/log/pcp/pmlogger`. Normally pcp running on the host creates `/var/log/pcp/pmlogger` and also does `chown pcp:pcp /var/log/pcp/pmlogger` if it does not exist. But `VOLUME /var/log/pcp/pmlogger` in the Dockerfile causes the directory to exist with owner `root:root` in the image.