### PR TITLE
Use ~postgres/data as PG_DATA

### DIFF
--- a/src/bci_build/package.py
+++ b/src/bci_build/package.py
@@ -1835,6 +1835,7 @@ POSTGRES_CONTAINERS = [
 {DOCKERFILE_RUN} chmod +x /usr/local/bin/docker-entrypoint.sh; \
     sed -i -e 's/exec gosu postgres "/exec setpriv --reuid=postgres --regid=postgres --clear-groups -- "/g' /usr/local/bin/docker-entrypoint.sh; \
     mkdir /docker-entrypoint-initdb.d; \
+    install -d -m 0700 -o postgres -g postgres $PGDATA; \
     sed -ri "s|^#?(listen_addresses)\s*=\s*\S+.*|\1 = '*'|" /usr/share/postgresql{ver}/postgresql.conf.sample
 
 STOPSIGNAL SIGINT

--- a/src/bci_build/package.py
+++ b/src/bci_build/package.py
@@ -1833,7 +1833,7 @@ POSTGRES_CONTAINERS = [
         exposes_tcp=[5432],
         custom_end=rf"""COPY docker-entrypoint.sh /usr/local/bin/
 {DOCKERFILE_RUN} chmod +x /usr/local/bin/docker-entrypoint.sh; \
-    ln -s su /usr/bin/gosu; \
+    sed -i -e 's/exec gosu postgres "/exec setpriv --reuid=postgres --regid=postgres --clear-groups -- "/g' /usr/local/bin/docker-entrypoint.sh; \
     mkdir /docker-entrypoint-initdb.d; \
     sed -ri "s|^#?(listen_addresses)\s*=\s*\S+.*|\1 = '*'|" /usr/share/postgresql{ver}/postgresql.conf.sample
 

--- a/src/bci_build/package.py
+++ b/src/bci_build/package.py
@@ -1814,7 +1814,7 @@ POSTGRES_CONTAINERS = [
             "LANG": "en_US.utf8",
             "PG_MAJOR": f"{ver}",
             "PG_VERSION": "%%pg_version%%",
-            "PGDATA": "/var/lib/postgresql/data",
+            "PGDATA": "/var/lib/pgsql/data",
         },
         extra_files={
             "docker-entrypoint.sh": _POSTGRES_ENTRYPOINT,
@@ -1829,7 +1829,7 @@ POSTGRES_CONTAINERS = [
                 parse_version="minor",
             )
         ],
-        volumes=["/var/lib/postgresql/data"],
+        volumes=["$PGDATA"],
         exposes_tcp=[5432],
         custom_end=rf"""COPY docker-entrypoint.sh /usr/local/bin/
 {DOCKERFILE_RUN} chmod +x /usr/local/bin/docker-entrypoint.sh; \

--- a/src/bci_build/templates.py
+++ b/src/bci_build/templates.py
@@ -41,9 +41,9 @@ LABEL com.suse.release-stage="{{ image.release_stage }}"
 {%- if image.entrypoint_user %}USER {{ image.entrypoint_user }}{% endif %}
 {%- if image.entrypoint_docker %}{{ image.entrypoint_docker }}{% endif %}
 {%- if image.cmd_docker %}{{ image.cmd_docker }}{% endif %}
-{%- if image.volume_dockerfile %}{{ image.volume_dockerfile }}{% endif %}
 {%- if image.expose_dockerfile %}{{ image.expose_dockerfile }}{% endif %}
 {% if image.dockerfile_custom_end %}{{ image.dockerfile_custom_end }}{% endif %}
+{%- if image.volume_dockerfile %}{{ image.volume_dockerfile }}{% endif %}
 """
 )
 

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -168,9 +168,9 @@ ENV GPP_path="/usr/bin/g++"
 
 ENTRYPOINT ["/usr/bin/emacs"]
 CMD ["/usr/bin/gcc"]
-VOLUME /bin/ /usr/bin/
 EXPOSE 22 1111
-RUN emacs -Q --batch""",
+RUN emacs -Q --batch
+VOLUME /bin/ /usr/bin/""",
             LanguageStackContainer(
                 exclusive_arch=[Arch.X86_64, Arch.S390X],
                 name="test",


### PR DESCRIPTION
the SUSE SLE packages are expecting to run postgresql below the postgres user home, and locating the data dir inside makes the docker entrypoint set permissions on the volume on first start.