### PR TITLE
reduce busybox image size by removing Index.db

### DIFF
--- a/src/bci_build/package.py
+++ b/src/bci_build/package.py
@@ -2156,7 +2156,13 @@ BUSYBOX_CONTAINERS = [
                 "ca-certificates-mozilla-prebuilt",
             )
         ],
-        config_sh_script="sed -i 's|/bin/bash|/bin/sh|' /etc/passwd",
+        config_sh_script=textwrap.dedent(
+            """
+            sed -i 's|/bin/bash|/bin/sh|' /etc/passwd
+            # Will be recreated by the next rpm(1) run as root user
+            rm -v /usr/lib/sysimage/rpm/Index.db
+        """
+        ),
         config_sh_interpreter="/bin/sh",
     )
     for os_version in (OsVersion.SP4, OsVersion.SP5, OsVersion.TUMBLEWEED)


### PR DESCRIPTION
Index.db is being created on demand by rpm(1) (as long as it is run as root) so we don't strictly have to ship it. currently the Index.db has a lot of empty space within which we could optimize away.

until then removing the file saves 10% of the total compressed size.