### PR TITLE
Use a repo scoped token for opening the automated PR

### DIFF
--- a/.github/workflows/update-deployment-branches.yml
+++ b/.github/workflows/update-deployment-branches.yml
@@ -77,18 +77,10 @@ jobs:
         uses: vsoch/pull-request-action@master
         id: create-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CHECKOUT_TOKEN }}
           PULL_REQUEST_FROM_BRANCH: ${{ env.BRANCH_NAME }}
           PULL_REQUEST_BRANCH: ${{ env.DEPLOYMENT_BRANCH_NAME }}
           PULL_REQUEST_TITLE: "🤖: Update build recipes for ${{ env.OS_VERSION_PRETTY }}"
           PULL_REQUEST_UPDATE: 1
           PULL_REQUEST_REVIEWERS: "fcrozat vmoutoussamy dirkmueller"
         if: env.no_change != 'true'
-
-        # see https://github.com/vsoch/pull-request-action/issues/30 for context
-      - name: Close and reopen the PR to trigger github actions
-        uses: dogmatic69/actions/automations/pr-toggle@master
-        env:
-          PULL_REQUEST_NUMBER: |
-            ${{ steps.create-pr.outputs.pull_request_number }}
-          GITHUB_TOKEN: '${{ secrets.PAT }}'


### PR DESCRIPTION
According to https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-536204092, that should result in the CI to actually run.