### PR TITLE
Add a space constraint for rmt-mariadb-image

### DIFF
--- a/src/bci_build/package.py
+++ b/src/bci_build/package.py
@@ -1731,7 +1731,10 @@ MARIADB_CONTAINERS = [
         custom_description="MariaDB server for RMT, based on the SLE Base Container Image.",
         package_list=["mariadb", "mariadb-tools", "gawk", "timezone", "util-linux"],
         entrypoint=["docker-entrypoint.sh"],
-        extra_files={"docker-entrypoint.sh": _MARIAD_ENTRYPOINT},
+        extra_files={
+            "docker-entrypoint.sh": _MARIAD_ENTRYPOINT,
+            "_constraints": generate_disk_size_constraints(11),
+        },
         build_recipe_type=BuildType.DOCKER,
         cmd=["mariadbd"],
         volumes=["/var/lib/mysql"],


### PR DESCRIPTION
Looks like the build does require at least 9.5GB.
This should ensure only proper worker are selected.