### PR TITLE
Allow everyone to trigger commands

### DIFF
--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -15,3 +15,4 @@ jobs:
             vc
             help
           issue-type: pull-request
+          permissions: none


### PR DESCRIPTION
Currently they are not security relevant and thus there's no real danger from anyone issuing them. However, atm non-maintainers cannot trigger the commands for some reason and this should enable it