### PR TITLE
Set the password_encryption to md5 when host auth is md5

### DIFF
--- a/src/bci_build/postgres/entrypoint.sh
+++ b/src/bci_build/postgres/entrypoint.sh
@@ -88,8 +88,10 @@ docker_init_database_dir() {
 		set -- --waldir "$POSTGRES_INITDB_WALDIR" "$@"
 	fi
 
+        [ -z "$POSTGRES_HOST_AUTH_METHOD" ] || AUTH_ARGS="--auth=${POSTGRES_HOST_AUTH_METHOD}"
+
 	# --pwfile refuses to handle a properly-empty file (hence the "\n"): https://github.com/docker-library/postgres/issues/1025
-	eval 'initdb --username="$POSTGRES_USER" --pwfile=<(printf "%s\n" "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"' "$@"'
+	eval 'initdb --username="$POSTGRES_USER" --pwfile=<(printf "%s\n" "$POSTGRES_PASSWORD") $AUTH_ARGS '"$POSTGRES_INITDB_ARGS"' "$@"'
 
 	# unset/cleanup "nss_wrapper" bits
 	if [[ "${LD_PRELOAD:-}" == */libnss_wrapper.so ]]; then


### PR DESCRIPTION
Systems with libpg < 10 cannot talk to the BCIs as they do not support SCRAM for authentication. Setting only `POSTGRES_HOST_AUTH_METHOD` to md5 is insufficient, as recent postgres versions will use SCRAM for password encryption. Thus we have to override the `password_encryption` in that case as well.

See also:
https://stackoverflow.com/questions/62807717/how-can-i-solve-postgresql-scram-authentication-problem/62808487#62808487