### PR TITLE
Set BuildRelease for oldstable images

### DIFF
--- a/src/bci_build/templates.py
+++ b/src/bci_build/templates.py
@@ -9,10 +9,15 @@ import jinja2
 DOCKERFILE_TEMPLATE = jinja2.Template(
     """{% if image.exclusive_arch %}#!ExclusiveArch: {% for arch in image.exclusive_arch %}{{ arch }}{{ " " if not loop.last }}{% endfor %}
 {% endif %}# SPDX-License-Identifier: {{ image.license }}
-{% for tag in image.build_tags -%}
+{%- for tag in image.build_tags %}
 #!BuildTag: {{ tag }}
-{% endfor -%}
-{% if image.build_version %}#!BuildVersion: {{ image.build_version }}{% endif %}
+{%- endfor %}
+{%- if image.build_version %}
+#!BuildVersion: {{ image.build_version }}
+{%- endif %}
+{%- if image.build_release %}
+#!BuildRelease: {{ image.build_release }}
+{%- endif %}
 {{ image.dockerfile_from_line }}
 
 MAINTAINER {{ image.maintainer }}

--- a/tests/test_build_recipe.py
+++ b/tests/test_build_recipe.py
@@ -305,7 +305,6 @@ RUN zypper -n in --no-recommends gcc emacs; zypper -n clean; rm -rf /var/log/*
 #!BuildTag: opensuse/bci/emacs:28
 #!BuildTag: opensuse/bci/emacs:28-%RELEASE%
 #!BuildTag: opensuse/bci/emacs:latest
-
 FROM suse/base:18
 
 MAINTAINER invalid@suse.com


### PR DESCRIPTION
When we switch a version from "stable" to "oldstable", we need to tell OBS the ci counter of the stable image so that the %RELEASE% remains incremental.