### PR TITLE
Prepend the stability_tag in the tag list

### DIFF
--- a/src/bci_build/package.py
+++ b/src/bci_build/package.py
@@ -1055,7 +1055,7 @@ class LanguageStackContainer(BaseContainerImage):
     @property
     def build_tags(self) -> List[str]:
         tags = []
-        # The stability-tags feature in containers. may result in the generation of
+        # The stability-tags feature in containers may result in the generation of
         # identical release numbers for the same version from two different package
         # containers, such as "oldstable" and "stable."
         #


### PR DESCRIPTION
The first tag that is set is used by the build service to define the binary resulting name. by using the stability tag we have a stable name which avoids constant fixing of aggregates.