### PR TITLE
Stop generating language pack and application stacks for SP4

### DIFF
--- a/src/dotnet/updater.py
+++ b/src/dotnet/updater.py
@@ -327,7 +327,7 @@ def _is_latest_dotnet(version: _DOTNET_VERSION_T, os_version: OsVersion) -> bool
 
 DOTNET_IMAGES: list[DotNetBCI] = []
 
-for os_version in (OsVersion.SP4, OsVersion.SP5):
+for os_version in (OsVersion.SP5,):
     for ver in _DOTNET_VERSIONS:
         package_list: list[Package | str] = [
             "dotnet-host",

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -3,7 +3,7 @@ import pathlib
 
 import pytest
 import yaml
-from bci_build.package import ALL_OS_VERSIONS
+from bci_build.package import ALL_NONBASE_OS_VERSIONS
 from bci_build.package import OsVersion
 from staging.bot import StagingBot
 
@@ -16,7 +16,7 @@ def run_in_tmp_path(tmp_path: pathlib.Path):
     os.chdir(cwd)
 
 
-@pytest.mark.parametrize("os_version", ALL_OS_VERSIONS)
+@pytest.mark.parametrize("os_version", ALL_NONBASE_OS_VERSIONS)
 @pytest.mark.parametrize("branch", ["", "something"])
 @pytest.mark.parametrize("packages", [None, ["pcp-image"]])
 @pytest.mark.parametrize(


### PR DESCRIPTION
We're no longer interested in those since the rollover to SP5. In order to prepare for a potential SP6 beta being introduced, split into a generic ALL_BASE_OS_VERSIONS and ALL_NONBASE_OS_VERSIONS so that this will be less churn going forward.