### PR TITLE
Don't include the version for LanguageStackContainers with version_in_uid=False

### DIFF
--- a/src/bci_build/package.py
+++ b/src/bci_build/package.py
@@ -1012,7 +1012,13 @@ exit 0
 
             if hasattr(self, "version"):
                 ver = getattr(self, "version")
-                if str(ver) not in name_to_include:
+                # we don't want to include the version for language stack
+                # containers with the version_in_uid flag set to False, but by
+                # default we include it (for os containers which don't have this
+                # flag)
+                if str(ver) not in name_to_include and not getattr(
+                    self, "version_in_uid", True
+                ):
                     name_to_include += f" {ver}"
             tasks.append(
                 asyncio.ensure_future(


### PR DESCRIPTION
This otherwise results in weird entries like:
```
First version of the Kubernetes Package Manager %%helm_version%% BCI
```
as seen in https://github.com/SUSE/BCI-dockerfile-generator/commit/3b649f2a79f4ccea4671029c52152053a28d7a8c