### PR TITLE
Add php8-readline extension on Tumbleweed

### DIFF
--- a/src/bci_build/package.py
+++ b/src/bci_build/package.py
@@ -1656,7 +1656,9 @@ EXPOSE 9000
 """
         )
     else:
-        extra_pkgs = []
+        extra_pkgs = (
+            [] if OS_VERSION != "tumbleweed" else [f"php{php_version}-readline"]
+        )
         extra_env = {}
         cmd = ["php", "-a"]
         custom_end = common_end

--- a/src/bci_build/package.py
+++ b/src/bci_build/package.py
@@ -1657,7 +1657,7 @@ EXPOSE 9000
         )
     else:
         extra_pkgs = (
-            [] if OS_VERSION != "tumbleweed" else [f"php{php_version}-readline"]
+            [] if os_version != OsVersion.TUMBLEWEED else [f"php{php_version}-readline"]
         )
         extra_env = {}
         cmd = ["php", "-a"]


### PR DESCRIPTION
It is no longer installed by default and required by php interactive mode (the default entrypoint), otherwise it just logs an assert and exits.