### PR TITLE
Limit Java containers to 64bit arch

### DIFF
--- a/src/bci_build/package.py
+++ b/src/bci_build/package.py
@@ -1489,6 +1489,8 @@ def _get_openjdk_kwargs(
     is_latest = java_version == 17 and os_version in CAN_BE_LATEST_OS_VERSION
 
     common = {
+        # Hardcoding /usr/lib64 in JAVA_HOME atm
+        "exclusive_arch": [Arch.AARCH64, Arch.X86_64, Arch.PPC64LE, Arch.S390X],
         "env": JAVA_ENV,
         "version": java_version,
         "os_version": os_version,


### PR DESCRIPTION
Currently JAVA_HOME and other related environment variables are hard-coded to /usr/lib64 and that makes them only work on those architectures.