### PR TITLE
Add util-linux to the java container (for /usr/bin/getopt)

### DIFF
--- a/src/bci_build/package.py
+++ b/src/bci_build/package.py
@@ -1520,7 +1520,7 @@ def _get_openjdk_kwargs(
             **common,
             "name": "openjdk",
             "pretty_name": f"OpenJDK {java_version} runtime",
-            "package_list": [f"java-{java_version}-openjdk"],
+            "package_list": [f"java-{java_version}-openjdk", "util-linux"],
         }
 
 


### PR DESCRIPTION
The testsuite depends on being able to install cassandra, which calls getopt