### PR TITLE
Remove unnecessary compat package

### DIFF
--- a/src/bci_build/package.py
+++ b/src/bci_build/package.py
@@ -2324,6 +2324,16 @@ MINIMAL_CONTAINERS = [
         package_name="minimal-image",
         os_version=os_version,
         build_recipe_type=BuildType.KIWI,
+        config_sh_script=textwrap.dedent(
+            """
+            #==========================================
+            # Remove compat-usrmerge-tools if installed
+            #------------------------------------------
+            if rpm -q compat-usrmerge-tools; then
+                rpm -e compat-usrmerge-tools
+            fi
+            """
+        ),
     )
     for os_version in ALL_BASE_OS_VERSIONS
 ]


### PR DESCRIPTION
This is only needed if rpm doesn't detect the usrmerge happened, which it doesn't in the kiwi build process. to be investigated