### PR TITLE
Use buildname when buildversion is also used

### DIFF
--- a/src/bci_build/package.py
+++ b/src/bci_build/package.py
@@ -538,6 +538,12 @@ class BaseContainerImage(abc.ABC):
         pass
 
     @property
+    def build_name(self) -> Optional[str]:
+        if self.build_tags:
+            return self.build_tags[0].replace("/", ":").replace(":", "-")
+        return None
+
+    @property
     def build_version(self) -> Optional[str]:
         if self.os_version not in (OsVersion.TUMBLEWEED, OsVersion.BASALT):
             epoch = ""

--- a/src/bci_build/templates.py
+++ b/src/bci_build/templates.py
@@ -12,7 +12,9 @@ DOCKERFILE_TEMPLATE = jinja2.Template(
 {% for tag in image.build_tags -%}
 #!BuildTag: {{ tag }}
 {% endfor -%}
-{% if image.build_version %}#!BuildVersion: {{ image.build_version }}{% endif %}
+{% if image.build_version %}#!BuildName: {{ image.build_name }}
+#!BuildVersion: {{ image.build_version }}
+{%- endif %}
 {{ image.dockerfile_from_line }}
 
 MAINTAINER {{ image.maintainer }}

--- a/tests/test_build_recipe.py
+++ b/tests/test_build_recipe.py
@@ -15,6 +15,7 @@ from bci_build.templates import KIWI_TEMPLATE
             """# SPDX-License-Identifier: MIT
 #!BuildTag: bci/test:28
 #!BuildTag: bci/test:28-%RELEASE%
+#!BuildName: bci-test-28
 #!BuildVersion: 15.4.28
 FROM suse/sle15:15.4
 
@@ -116,6 +117,7 @@ RUN emacs -Q --batch test.el
 #!BuildTag: bci/test:stable-1.%RELEASE%
 #!BuildTag: bci/test:%%emacs_ver%%
 #!BuildTag: bci/test:%%emacs_ver%%-1.%RELEASE%
+#!BuildName: bci-test-stable
 #!BuildVersion: 15.5
 FROM suse/sle15:15.5
 
@@ -208,6 +210,7 @@ RUN zypper -n in --no-recommends gcc emacs; zypper -n clean; rm -rf /var/log/*
             """# SPDX-License-Identifier: MIT
 #!BuildTag: bci/test:28
 #!BuildTag: bci/test:28-%RELEASE%
+#!BuildName: bci-test-28
 #!BuildVersion: 15.4.28
 FROM suse/sle15:15.4
 


### PR DESCRIPTION
with https://github.com/openSUSE/obs-build/commit/1a8b6a8889dc63c45776baacbcf60eca6a353226 the build service changed behavior for dockerfiles that use BuildVersion. It now expects buildname to be set as well, otherwise buildversion is ignored. Specify buildname in those cases with exactly the same name as before.