### PR TITLE
Add lifecycle data into the python containers

### DIFF
--- a/src/bci_build/package/python.py
+++ b/src/bci_build/package/python.py
@@ -41,7 +41,8 @@ def _get_python_kwargs(
             if is_system_py or os_version == OsVersion.TUMBLEWEED
             else []
         )
-        + ([f"{py3}-pipx"] if os_version == OsVersion.TUMBLEWEED else []),
+        + ([f"{py3}-pipx"] if os_version == OsVersion.TUMBLEWEED else [])
+        + os_version.lifecycle_data_pkg,
         "replacements_via_service": [
             Replacement(
                 regex_in_build_description=py3_ver_replacement,


### PR DESCRIPTION
At least the 3.11 container has a specified lifecycle, so the lifecycle data should be included inside the container