### PR TITLE
Fix PHP containers for SP6

### DIFF
--- a/src/bci_build/package/php.py
+++ b/src/bci_build/package/php.py
@@ -117,7 +117,9 @@ EXPOSE 9000
         )
     else:
         extra_pkgs = (
-            [] if os_version != OsVersion.TUMBLEWEED else [f"php{php_version}-readline"]
+            []
+            if os_version not in (OsVersion.TUMBLEWEED, OsVersion.SP6)
+            else [f"php{php_version}-readline"]
         )
         extra_env = {}
         cmd = ["php", "-a"]


### PR DESCRIPTION
Similarly to tumbleweed we have a newer php version that requires the extra readline subpackage to be installed.