### PR TITLE
Adding node and git for ci exec

### DIFF
--- a/src/bci_build/package/basecontainers.py
+++ b/src/bci_build/package/basecontainers.py
@@ -266,6 +266,8 @@ GITEA_RUNNER_CONTAINER = OsContainer(
         "osc",
         "expect",
         "obs-service-source_validator",
+        "typescript",
+        "git",
         *_get_os_container_package_names(OsVersion.TUMBLEWEED),
     ],
     extra_files={"osc_checkout": OSC_CHECKOUT},


### PR DESCRIPTION
Missing the ci require packages for gitea actions, typescript provide node and git command as well. 