### PR TITLE
Add pwgen for MARIADB_RANDOM_ROOT_PASSWORD

### DIFF
--- a/src/bci_build/package/appcontainers.py
+++ b/src/bci_build/package/appcontainers.py
@@ -162,7 +162,8 @@ for os_version in set(ALL_NONBASE_OS_VERSIONS) | {OsVersion.BASALT}:
                 )
             ],
             pretty_name="MariaDB Server",
-            package_list=["mariadb", "mariadb-tools", "gawk", "timezone", "util-linux"],
+            package_list=["mariadb", "mariadb-tools", "gawk", "timezone", "util-linux"]
+            + (["pwgen"] if os_version == OsVersion.TUMBLEWEED else []),
             entrypoint=["docker-entrypoint.sh"],
             extra_files={
                 "docker-entrypoint.sh": _MARIAD_ENTRYPOINT,


### PR DESCRIPTION
This is an optional feature to generate a secure root password. pwgen is not available on any other distro than tumbleweed