### PR TITLE
set mariadbd as PID 1 in container

### DIFF
--- a/src/bci_build/package/appcontainers.py
+++ b/src/bci_build/package/appcontainers.py
@@ -179,7 +179,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 {DOCKERFILE_RUN} chmod 755 /usr/local/bin/docker-entrypoint.sh
 {DOCKERFILE_RUN} ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 
-{DOCKERFILE_RUN} sed -i 's#gosu mysql#su mysql -s /bin/bash -m#g' /usr/local/bin/docker-entrypoint.sh
+{DOCKERFILE_RUN} sed -i -e 's,exec gosu mysql ,exec setpriv --reuid=mysql --regid=mysql --clear-groups -- /bin/bash ,g' /usr/local/bin/docker-entrypoint.sh
 
 # Ensure all logs goes to stdout
 {DOCKERFILE_RUN} sed -i 's/^log/#log/g' /etc/my.cnf


### PR DESCRIPTION
This is necessary for stop/start operations to work properly, otherwise the container gets killed because "su" is not terminating.