### PR TITLE
Support signing of KMPs inside the kernel-module-devel container

### DIFF
--- a/src/bci_build/package/basecontainers.py
+++ b/src/bci_build/package/basecontainers.py
@@ -242,6 +242,7 @@ for os_version in ALL_OS_VERSIONS - {OsVersion.TUMBLEWEED}:
                 "make",
                 "patch",
                 "awk",
+                "rpm-build",
             ]
             # tar is not in bci-base in 15.4, but we need it to unpack tarballs
             + (["tar"] if os_version == OsVersion.SP4 else []),


### PR DESCRIPTION
See https://documentation.suse.com/sbp/server-linux/html/SBP-KMP-Manual-SLE12SP2/index.html#sec-sign-existing-kmp