### PR TITLE
Adding format_spec_file service

### DIFF
--- a/src/bci_build/package/basecontainers.py
+++ b/src/bci_build/package/basecontainers.py
@@ -266,6 +266,7 @@ GITEA_RUNNER_CONTAINER = OsContainer(
     package_list=[
         "osc",
         "expect",
+        "obs-service-format_spec_file",
         "obs-service-source_validator",
         "typescript",
         "git",


### PR DESCRIPTION
include another locally run osc service format_spec_file module in the gitea ci image. 