### PR TITLE
Add openssh-clients and catatonit to git

### DIFF
--- a/src/bci_build/package/appcontainers.py
+++ b/src/bci_build/package/appcontainers.py
@@ -517,7 +517,11 @@ GIT_CONTAINERS = [
         license="GPL-2.0-only",
         package_list=[
             Package(name, pkg_type=PackageType.BOOTSTRAP)
-            for name in ("git-core",)
+            for name in (
+                "catatonit",
+                "git-core",
+                "openssh-clients",
+            )
             + (() if os_version == OsVersion.TUMBLEWEED else ("skelcd-EULA-bci",))
         ],
         # intentionally empty

--- a/src/bci_build/package/appcontainers.py
+++ b/src/bci_build/package/appcontainers.py
@@ -518,7 +518,6 @@ GIT_CONTAINERS = [
         package_list=[
             Package(name, pkg_type=PackageType.BOOTSTRAP)
             for name in (
-                "catatonit",
                 "git-core",
                 "openssh-clients",
             )


### PR DESCRIPTION
openssh-clients should enable git repositories to be cloned via SSH.
Catatonit is needed for some use cases involving jobs, such as [1].

[1]: https://github.com/rancher/gitjob/commit/b2a3eaf53efd