### PR TITLE
Add rendering READMEs from a jinja template stored in git

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -18,6 +18,7 @@ from typing import Optional
 from typing import Union
 from typing import overload
 
+import jinja2
 from packaging import version
 
 from bci_build.templates import DOCKERFILE_TEMPLATE
@@ -1006,6 +1007,10 @@ exit 0
                 return self.extra_files["README.md"].decode("utf-8")
             return str(self.extra_files["README.md"])
 
+        readme_template_fname = Path(__file__).parent / self.name / "README.md.j2"
+        if readme_template_fname.exists():
+            return jinja2.Template(readme_template_fname.read_text()).render(image=self)
+
         return f"""# The {self.title} Container image
 
 {self.description}
@@ -1182,6 +1187,10 @@ exit 0
         for fname, contents in self.extra_files.items():
             files.append(fname)
             tasks.append(write_file_to_dest(fname, contents))
+
+        if "README.md" not in self.extra_files:
+            files.append("README.md")
+            tasks.append(write_file_to_dest("README.md", self.readme))
 
         await asyncio.gather(*tasks)
 

--- a/src/bci_build/package/basecontainers.py
+++ b/src/bci_build/package/basecontainers.py
@@ -36,6 +36,7 @@ MICRO_CONTAINERS = [
         os_version=os_version,
         support_level=SupportLevel.L3,
         package_name="micro-image",
+        logo_url="https://opensource.suse.com/bci/SLE_BCI_logomark_green.svg",
         is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
         pretty_name=f"{os_version.pretty_os_version_no_dash} Micro",
         custom_description="A micro environment for containers {based_on_container}.",
@@ -78,6 +79,7 @@ INIT_CONTAINERS = [
             "usage": "This container should only be used to build containers for daemons. Add your packages and enable services using systemctl."
         },
         package_name="init-image",
+        logo_url="https://opensource.suse.com/bci/SLE_BCI_logomark_green.svg",
         custom_end=textwrap.dedent(
             f"""
             RUN mkdir -p /etc/systemd/system.conf.d/ && \\
@@ -170,6 +172,7 @@ MINIMAL_CONTAINERS = [
         support_level=SupportLevel.L3,
         is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
         package_name="minimal-image",
+        logo_url="https://opensource.suse.com/bci/SLE_BCI_logomark_green.svg",
         os_version=os_version,
         build_recipe_type=BuildType.KIWI,
         config_sh_script=textwrap.dedent(
@@ -194,6 +197,7 @@ BUSYBOX_CONTAINERS = [
         support_level=SupportLevel.L3,
         pretty_name=f"{os_version.pretty_os_version_no_dash} BusyBox",
         package_name="busybox-image",
+        logo_url="https://opensource.suse.com/bci/SLE_BCI_logomark_green.svg",
         is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
         build_recipe_type=BuildType.KIWI,
         cmd=["/bin/sh"],
@@ -234,6 +238,7 @@ for os_version in ALL_OS_VERSIONS - {OsVersion.TUMBLEWEED}:
             name=f"{prefix}-kernel-module-devel",
             pretty_name=f"{pretty_prefix} Kernel Module Development",
             package_name=f"{prefix}-kernel-module-devel-image",
+            logo_url="https://opensource.suse.com/bci/SLE_BCI_logomark_green.svg",
             os_version=os_version,
             is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
             package_list=[

--- a/src/bci_build/package/busybox/README.md.j2
+++ b/src/bci_build/package/busybox/README.md.j2
@@ -1,12 +1,6 @@
-# SLE BCI-BusyBox: When you need the smallest and GPLv3-free image
+# SLE BCI-BusyBox: the smallest and GPLv3-free image
 
-Similar to SLE BCI-Micro, the SLE BCI-BusyBox image comes with the most
-basic tools only. However, these tools are provided by the BusyBox
-project. This has the benefit of further size reduction. Furthermore,
-the image contains no GPLv3 licensed software. When using the image,
-keep in mind that there are certain differences between the BusyBox
-tools and the GNU Coreutils. So scripts written for a system that
-uses GNU Coreutils may require modification to work with BusyBox.
+The SLE BCI-BusyBox image comes with the most basic tools provided by the BusyBox project. The image contains no GPLv3 licensed software. When using the image, keep in mind that there are differences between the BusyBox tools and the GNU Coreutils. This means that scripts written for a system that uses GNU Coreutils may require modification to work with BusyBox.
 
 ## License
  SPDX-License-Identifier: {{ image.license }}

--- a/src/bci_build/package/busybox/README.md.j2
+++ b/src/bci_build/package/busybox/README.md.j2
@@ -1,0 +1,12 @@
+# SLE BCI-BusyBox: When you need the smallest and GPLv3-free image
+
+Similar to SLE BCI-Micro, the SLE BCI-BusyBox image comes with the most
+basic tools only. However, these tools are provided by the BusyBox
+project. This has the benefit of further size reduction. Furthermore,
+the image contains no GPLv3 licensed software. When using the image,
+keep in mind that there are certain differences between the BusyBox
+tools and the GNU Coreutils. So scripts written for a system that
+uses GNU Coreutils may require modification to work with BusyBox.
+
+## License
+ SPDX-License-Identifier: {{ image.license }}

--- a/src/bci_build/package/micro/README.md.j2
+++ b/src/bci_build/package/micro/README.md.j2
@@ -1,0 +1,12 @@
+# SLE BCI-Micro: When you need to deploy static binaries
+
+This image is similar to SLE BCI-Minimal but without the RPM package manager.
+The primary use case for the image is deploying static binaries produced
+externally or during multi-stage builds. As there is no straightforward
+way to install additional dependencies inside the container image,
+we recommend deploying a project using the SLE BCI-Minimal image only
+when the final build artifact bundles all dependencies and has no
+external runtime requirements (like Python or Ruby).
+
+## License
+ SPDX-License-Identifier: {{ image.license }}

--- a/src/bci_build/package/micro/README.md.j2
+++ b/src/bci_build/package/micro/README.md.j2
@@ -1,4 +1,4 @@
-# SLE BCI-Micro: When you need to deploy static binaries
+# SLE BCI-Micro: Suitable for deploying static binaries
 
 This image is similar to SLE BCI-Minimal but without the RPM package manager.
 The primary use case for the image is deploying static binaries produced

--- a/src/bci_build/package/minimal/README.md.j2
+++ b/src/bci_build/package/minimal/README.md.j2
@@ -1,0 +1,15 @@
+# SLE BCI-Minimal: When you do not need Zypper
+
+This is a stripped-down version of the SLE BCI-Base image. SLE BCI-Minimal
+comes without Zypper, but it does have the RPM package manager installed.
+This significantly reduces the size of the image. However, while RPM can
+install and remove packages, it lacks support for repositories and
+automated dependency resolution. The SLE BCI-Minimal image is therefore
+intended for creating deployment containers, and then installing the
+desired RPM packages inside the containers. Although you can install
+the required dependencies, you need to download and resolve them
+manually. However, this approach is not recommended as it is
+prone to errors.
+
+## License
+ SPDX-License-Identifier: {{ image.license }}

--- a/src/bci_build/package/minimal/README.md.j2
+++ b/src/bci_build/package/minimal/README.md.j2
@@ -1,15 +1,6 @@
-# SLE BCI-Minimal: When you do not need Zypper
+# SLE BCI-Minimal: Container image without Zypper
 
-This is a stripped-down version of the SLE BCI-Base image. SLE BCI-Minimal
-comes without Zypper, but it does have the RPM package manager installed.
-This significantly reduces the size of the image. However, while RPM can
-install and remove packages, it lacks support for repositories and
-automated dependency resolution. The SLE BCI-Minimal image is therefore
-intended for creating deployment containers, and then installing the
-desired RPM packages inside the containers. Although you can install
-the required dependencies, you need to download and resolve them
-manually. However, this approach is not recommended as it is
-prone to errors.
+SLE BCI-Minimal comes without Zypper, but it does have the RPM package manager installed. While RPM can install and remove packages, it lacks support for repositories and automated dependency resolution. The SLE BCI-Minimal image is therefore intended for creating deployment containers, and then installing the desired RPM packages inside the containers. While you can install the required dependencies, you need to download and resolve them manually. However, this approach is not recommended as it is prone to errors.
 
 ## License
  SPDX-License-Identifier: {{ image.license }}

--- a/src/bci_build/package/registry/README.md.j2
+++ b/src/bci_build/package/registry/README.md.j2
@@ -1,0 +1,41 @@
+# The SLE BCI Distribution Image
+
+This container image allows to run a local OCI registry. Before you start the container,
+you need to create a `config.yml` with the following content:
+
+```yaml
+---
+version: 0.1
+log:
+  level: info
+storage:
+  filesystem:
+    rootdirectory: /var/lib/docker-registry
+http:
+  addr: 0.0.0.0:5000
+```
+
+You can also create an empty directory to persistently store the images outside the container:
+
+```bash
+mkdir -p /var/lib/docker-registry
+```
+
+Then you can start the container with the following command:
+
+```bash
+podman run -d --restart=always -p 5000:5000 -v /path/to/config.yml:/etc/docker/registry/config.yml \
+  -v /var/lib/docker-registry:/var/lib/docker-registry --name registry {{ image.reference }}
+```
+
+The registry will be available at `http://localhost:5000`. To keep the registry running after a reboot,
+you can create a systemd service:
+
+```bash
+sudo podman generate systemd registry > /etc/systemd/system/registry.service
+sudo systemctl enable --now registry
+```
+
+
+## License
+ SPDX-License-Identifier: {{ image.license }}

--- a/src/bci_build/package/registry/README.md.j2
+++ b/src/bci_build/package/registry/README.md.j2
@@ -15,7 +15,7 @@ http:
   addr: 0.0.0.0:5000
 ```
 
-You can also create an empty directory to persistently store the images outside the container:
+You can also create an empty directory for storing the images outside the container:
 
 ```bash
 mkdir -p /var/lib/docker-registry
@@ -28,8 +28,7 @@ podman run -d --restart=always -p 5000:5000 -v /path/to/config.yml:/etc/docker/r
   -v /var/lib/docker-registry:/var/lib/docker-registry --name registry {{ image.reference }}
 ```
 
-The registry will be available at `http://localhost:5000`. To keep the registry running after a reboot,
-you can create a systemd service:
+The registry is available at `http://localhost:5000`. To keep the registry running after a reboot, create a systemd service as follows:
 
 ```bash
 sudo podman generate systemd registry > /etc/systemd/system/registry.service

--- a/src/staging/bot.py
+++ b/src/staging/bot.py
@@ -1047,17 +1047,10 @@ PACKAGES={','.join(self.package_names) if self.package_names else None}
                 if isinstance(bci_pkg, DotNetBCI):
                     bci_pkg.generate_custom_end()
 
-                async def write_readme() -> str:
-                    async with aiofiles.open(
-                        os.path.join(destination_prj_folder, bci_pkg.readme_path), "w"
-                    ) as readme_md_f:
-                        await readme_md_f.write(bci_pkg.readme)
-                    return bci_pkg.readme_path
-
                 return [
                     f"{bci_pkg.package_name}/{fname}"
                     for fname in await bci_pkg.write_files_to_folder(dest)
-                ] + [await write_readme()]
+                ]
 
             img_dest_dir = os.path.join(destination_prj_folder, bci.package_name)
             tasks.append(write_files(bci, img_dest_dir))


### PR DESCRIPTION
If README.md is not already injected via extra_files, the generator now looks for a README.md.j2 in the package directory and renders it instead.