### PR TITLE
Remove ArchExclusiveLine that doesn't filter anything out

### DIFF
--- a/src/bci_build/package/golang.py
+++ b/src/bci_build/package/golang.py
@@ -64,13 +64,7 @@ def _get_golang_kwargs(
                 regex_in_build_description=golang_version_regex, package_name=go
             )
         ],
-        "custom_end": textwrap.dedent(
-            f"""
-            # only available on go's tsan_arch architectures
-            #!ArchExclusiveLine x86_64 aarch64 s390x ppc64le
-            {DOCKERFILE_RUN} if zypper -n install {go}-race; then zypper -n clean; rm -rf /var/log/*; fi
-            """
-        ),
+        "custom_end": f"{DOCKERFILE_RUN} zypper -n install {go}-race; zypper -n clean; rm -rf /var/log/*;",
         "package_list": [*go_packages, "make", "git-core"]
         + os_version.lifecycle_data_pkg,
         "extra_files": {


### PR DESCRIPTION
We build only on the specified architectures, hence the filtering is not necessary. At best we mask errors to install the golang race detector.