### PR TITLE
Use the LTSS base containers for LTSS builds

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -756,7 +756,13 @@ exit 0
             return "opensuse/tumbleweed:latest"
         if self.os_version == OsVersion.BASALT:
             return f"{_build_tag_prefix(self.os_version)}/bci-base:latest"
+        if self.os_version in ALL_OS_LTSS_VERSIONS:
+            return f"{_build_tag_prefix(self.os_version)}/sle15:15.{self.os_version}"
+        if self.image_type == ImageType.APPLICATION:
+            return f"suse/sle15:15.{self.os_version}"
 
+        # TODO(dmllr): Change to the redistributable image bci/bci-base:15.$SP
+        # once we can agree on the split
         return f"suse/sle15:15.{self.os_version}"
 
     @property

--- a/tests/test_build_recipe.py
+++ b/tests/test_build_recipe.py
@@ -25,7 +25,7 @@ from bci_build.templates import KIWI_TEMPLATE
 #!BuildTag: bci/test:28-%RELEASE%
 #!BuildName: bci-test-28
 #!BuildVersion: 15.4.28
-FROM suse/sle15:15.4
+FROM suse/ltss/sle15.4/sle15:15.4
 
 MAINTAINER SUSE LLC (https://www.suse.com/)
 
@@ -65,7 +65,7 @@ RUN emacs -Q --batch test.el
     <specification>SLE BCI Test Container Image</specification>
   </description>
   <preferences>
-    <type image="docker" derived_from="obsrepositories:/suse/sle15#15.4">
+    <type image="docker" derived_from="obsrepositories:/suse/ltss/sle15.4/sle15#15.4">
       <containerconfig
           name="bci/test"
           tag="28"
@@ -224,7 +224,7 @@ RUN zypper -n in --no-recommends gcc emacs; zypper -n clean; ##LOGCLEAN##
 #!BuildTag: bci/test:28-%RELEASE%
 #!BuildName: bci-test-28
 #!BuildVersion: 15.4.28
-FROM suse/sle15:15.4
+FROM suse/ltss/sle15.4/sle15:15.4
 
 MAINTAINER SUSE LLC (https://www.suse.com/)
 
@@ -261,7 +261,7 @@ RUN zypper -n in --no-recommends gcc emacs; zypper -n clean; ##LOGCLEAN##
     <specification>SLE BCI Test Container Image</specification>
   </description>
   <preferences>
-    <type image="docker" derived_from="obsrepositories:/suse/sle15#15.4">
+    <type image="docker" derived_from="obsrepositories:/suse/ltss/sle15.4/sle15#15.4">
       <containerconfig
           name="bci/test"
           tag="28"


### PR DESCRIPTION
This also fixes the default base container to bci-base rather than sle15