### PR TITLE
Also install openjdk21 explicitly

### DIFF
--- a/src/bci_build/package/appcontainers.py
+++ b/src/bci_build/package/appcontainers.py
@@ -683,7 +683,11 @@ TOMCAT_CONTAINERS = [
                 else f"tomcat{tomcat_major}"
             )
         ]
-        + (["java-21-openjdk-headless"] if os_version == OsVersion.SP6 else []),
+        + (
+            ["java-21-openjdk", "java-21-openjdk-headless"]
+            if os_version == OsVersion.SP6
+            else []
+        ),
         replacements_via_service=[
             Replacement(
                 regex_in_build_description="%%tomcat_version%%", package_name=tomcat_pkg


### PR DESCRIPTION
-headless subpackage is not actually requiring the main jre like expected, so we need to install that one as well to avoid jdk 11 being pulled in.