### PR TITLE
Split redistributable from non-distributable base container

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -766,9 +766,7 @@ exit 0
         if self.image_type == ImageType.APPLICATION:
             return f"suse/sle15:15.{self.os_version}"
 
-        # TODO(dmllr): Change to the redistributable image bci/bci-base:15.$SP
-        # once we can agree on the split
-        return f"suse/sle15:15.{self.os_version}"
+        return f"bci/bci-base:15.{self.os_version}"
 
     @property
     def dockerfile_from_line(self) -> str:

--- a/tests/test_build_recipe.py
+++ b/tests/test_build_recipe.py
@@ -129,7 +129,7 @@ RUN emacs -Q --batch test.el
 #!BuildTag: bci/test:%%emacs_ver%%-1.%RELEASE%
 #!BuildName: bci-test-stable
 #!BuildVersion: 15.5
-FROM suse/sle15:15.5
+FROM bci/bci-base:15.5
 
 MAINTAINER SUSE LLC (https://www.suse.com/)
 
@@ -166,7 +166,7 @@ RUN zypper -n in --no-recommends gcc emacs; zypper -n clean; ##LOGCLEAN##
     <specification>SLE BCI Test Container Image</specification>
   </description>
   <preferences>
-    <type image="docker" derived_from="obsrepositories:/suse/sle15#15.5">
+    <type image="docker" derived_from="obsrepositories:/bci/bci-base#15.5">
       <containerconfig
           name="bci/test"
           tag="stable"


### PR DESCRIPTION
The EULA's are different, we should separate them accordingly.