### PR TITLE
Remove tomcat-docs-webapp from readme

### DIFF
--- a/src/bci_build/package/tomcat/README.md.j2
+++ b/src/bci_build/package/tomcat/README.md.j2
@@ -68,7 +68,6 @@ the container image. Add them by installing one of the following
 packages:
 - {{ image.package_list[0] }}-webapps
 - {{ image.package_list[0] }}-admin-webapps
-- {{ image.package_list[0] }}-docs-webapp
 
 {% if image.env['TOMCAT_MAJOR'] > 9 -%}
 ## Upgrading from Tomcat 9


### PR DESCRIPTION
this is not part of the web and scripting module today, so it cannot be installed.