### PR TITLE
Remove Version identifier for the Tumbleweed BCI containers

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -155,7 +155,9 @@ class OsVersion(enum.Enum):
     @property
     def pretty_os_version_no_dash(self) -> str:
         if self.value == OsVersion.TUMBLEWEED.value:
-            return f"openSUSE {self.value}"
+            # TW has no version by itself and the "openSUSE Tumbleweed" is
+            # already part of the base identifier
+            return ""
         if self.value == OsVersion.BASALT.value:
             return "Adaptable Linux Platform"
 
@@ -530,6 +532,8 @@ class BaseContainerImage(abc.ABC):
     _image_properties: ImageProperties = field(default=_SLE_IMAGE_PROPS)
 
     def __post_init__(self) -> None:
+        self.pretty_name = self.pretty_name.strip()
+
         if not self.package_list:
             raise ValueError(f"No packages were added to {self.pretty_name}.")
         if self.exclusive_arch and Arch.LOCAL in self.exclusive_arch:

--- a/tests/test_build_recipe.py
+++ b/tests/test_build_recipe.py
@@ -484,7 +484,7 @@ def test_build_recipe_templates(
   <description type="system">
     <author>openSUSE Project</author>
     <contact>https://www.suse.com/</contact>
-    <specification>openSUSE Tumbleweed BCI openSUSE Tumbleweed Test Container Image</specification>
+    <specification>openSUSE Tumbleweed BCI Test Container Image</specification>
   </description>
   <preferences>
     <type image="docker">
@@ -495,7 +495,7 @@ def test_build_recipe_templates(
           additionaltags="%OS_VERSION_ID_SP%.%RELEASE%,latest">
         <labels>
           <suse_label_helper:add_prefix prefix="org.opensuse.bci.test">
-            <label name="org.opencontainers.image.title" value="openSUSE Tumbleweed BCI openSUSE Tumbleweed Test"/>
+            <label name="org.opencontainers.image.title" value="openSUSE Tumbleweed BCI Test"/>
             <label name="org.opencontainers.image.description" value="A test environment for containers."/>
             <label name="org.opencontainers.image.version" value="%OS_VERSION_ID_SP%.%RELEASE%"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>


### PR DESCRIPTION
These are ugly duplications of the distribution prefix already, Tumbleweeda as a rolling release has no version on its own.