### PR TITLE
Fixup README sections

### DIFF
--- a/src/bci_build/package/base-fips/README.md.j2
+++ b/src/bci_build/package/base-fips/README.md.j2
@@ -1,6 +1,7 @@
 # The SUSE Linux Enterprise 15 SP3 FIPS-140-2 Container image
 {% include 'badges.j2' %}
 
+## Description
 This container image is a SUSE Linux Enterprise 15 SP3 base container image
 that includes the SLES 15 FIPS-140-2 certified OpenSSL module.
 
@@ -13,6 +14,7 @@ standard OpenSSL library. It provides the same functionality as the standard
 OpenSSL library, with additional security features to meet the FIPS-140-2
 requirements.
 
+## Usage
 The image is configured to enforce the use of FIPS-140 mode by default via the
 environment variable `OPENSSL_FORCE_FIPS_MODE`. This variable is set to `1` in
 the image. This means that all cryptographic operations performed by the

--- a/src/bci_build/package/busybox/README.md.j2
+++ b/src/bci_build/package/busybox/README.md.j2
@@ -1,11 +1,12 @@
-# SLE BCI-BusyBox: the smallest and GPLv3-free image
+# {{ image.title }}: the smallest and GPLv3-free image
 {% include 'badges.j2' %}
 
-The SLE BCI-BusyBox image comes with the most basic tools provided by the BusyBox project.
+## Description
+This image comes with the most basic tools provided by the BusyBox project.
 The image contains no GPLv3 licensed software. When using the image, keep in mind that
 there are differences between the BusyBox tools and the GNU Coreutils.
 This means that scripts written for a system that uses GNU Coreutils may require
 modification to work with BusyBox. If you need a SLES compatible image with the GNU Coreutils,
-consider using the SLE BCI-Micro image instead.
+consider using the corresponding Micro image instead.
 
 {% include 'licensing_and_eula.j2' %}

--- a/src/bci_build/package/gcc/README.md.j2
+++ b/src/bci_build/package/gcc/README.md.j2
@@ -1,12 +1,14 @@
-# The GNU Compiler Collection Container Image
+# {{ image.title }} Container Image (GCC)
 {% include 'badges.j2' %}
+
+# Description
 The GNU Compiler Collection (GCC) is an optimizing compiler for various
 architectures and operating systems. It is the default compiler in the GNU
 project and most Linux distributions, including SUSE Linux Enterprise and
 openSUSE.
 
 
-## How to use the image
+## Usage
 
 ### Compile an application with a `Dockerfile`
 

--- a/src/bci_build/package/mariadb/README.md.j2
+++ b/src/bci_build/package/mariadb/README.md.j2
@@ -1,9 +1,10 @@
 # {{ image.pretty_name }} Container Image
 
+## Description
 MariaDB is an open-source, multi-threaded, relational database management system. It's a backward-compatible branch of the MySQL Community Server that provides a drop-in replacement for MySQL.
 
-## Using the image
 
+## Usage
 By default, the image launches MariaDB with the same configuration that comes with SUSE Linux Enterprise Server, with two exceptions: logging is sent to stdout, and binding to `localhost` is disabled.
 
 The only environment variable required to start the container is the MariaDB root password.
@@ -18,7 +19,7 @@ or:
 $ podman run -it --rm -p 3306:3306 -e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=1 {{ image.pretty_reference }}
 ```
 
-## Volumes
+### Volumes
 
 The database is stored in the directory `/var/lib/mysql`.
 
@@ -35,7 +36,7 @@ $ podman run -it --rm -v /my/own/datadir:/var/lib/mysql:Z -p 3306:3306 -e MARIAD
 
 The `-v /my/own/datadir:/var/lib/mysql:Z` part of the command mounts the `/my/own/datadir` directory from the underlying host system as `/var/lib/mysql` inside the container, where MariaDB will by default write its data files.
 
-## Environment Variables
+### Environment variables
 
 One of `MARIADB_RANDOM_ROOT_PASSWORD`, `MARIADB_ROOT_PASSWORD_HASH`, `MARIADB_ROOT_PASSWORD` or `MARIADB_ALLOW_EMPTY_ROOT_PASSWORD` (or equivalents, including `*_FILE`), is required.
 
@@ -43,7 +44,7 @@ All other environment variables are optional.
 
 All environment variables are documented in the MariaDB's Knowledge Base [MariaDB Server Docker Official Image Environment Variables](https://mariadb.com/kb/en/mariadb-server-docker-official-image-environment-variables/).
 
-## Health, liveness and readiness
+### Health, liveness and readiness
 
 There are no explicit health checks added to the container image. However, you can use the `healthcheck.sh` script to choose from a limited selection of tests to check for what you consider health, liveness, and readiness.
 
@@ -57,7 +58,7 @@ If you start a MariaDB container instance with a data directory that already con
 
 The only exception is the `MARIADB_AUTO_UPGRADE` environment variable. If it's set, it may run `mysql_upgrade` or `mariadb-upgrade`, potentially causing changes to the system tables.
 
-## Backup and restore
+### Backup and restore
 
 Information on how to perform backup and restore can be found on the MariaDB Knowledge Base [Container Backup and Restoration](https://mariadb.com/kb/en/container-backup-and-restoration/).
 

--- a/src/bci_build/package/micro/README.md.j2
+++ b/src/bci_build/package/micro/README.md.j2
@@ -1,10 +1,12 @@
-# SLE BCI-Micro: Suitable for deploying static binaries
+# {{ image.title }}: Suitable for deploying static binaries
 {% include 'badges.j2' %}
-This image is similar to SLE BCI-Minimal but without the RPM package manager.
+
+## Description
+This image is similar to Minimal but without the RPM package manager.
 The primary use case for the image is deploying static binaries produced
 externally or during multi-stage builds. As there is no straightforward
 way to install additional dependencies inside the container image,
-we recommend deploying a project using the SLE BCI-Minimal image only
+we recommend deploying a project using the Minimal image only
 when the final build artifact bundles all dependencies and has no
 external runtime requirements (like Python or Ruby).
 

--- a/src/bci_build/package/minimal/README.md.j2
+++ b/src/bci_build/package/minimal/README.md.j2
@@ -1,8 +1,10 @@
-# SLE BCI-Minimal: Base Container image without Zypper
+# {{ image.title }}: Base Container image without Zypper
 {% include 'badges.j2' %}
-SLE BCI-Minimal comes without Zypper, but it does have the RPM package manager installed.
+
+## Description
+This image comes without Zypper, but it does have the RPM package manager installed.
 While RPM can install and remove packages, it lacks support for repositories and automated dependency resolution.
-The SLE BCI-Minimal image is therefore intended for creating deployment containers, and then installing the desired
+It is therefore intended for creating deployment containers, and then installing the desired
 RPM packages inside the containers.
 
 While you can install the required dependencies, you need to download and resolve them manually.

--- a/src/bci_build/package/pcp/README.md.j2
+++ b/src/bci_build/package/pcp/README.md.j2
@@ -1,6 +1,7 @@
-# Performance Co-Pilot container
+# {{ image.title}}: Performance Co-Pilot
 {% include 'badges.j2' %}
 
+## Description
 Performance Co-Pilot ([PCP](https://pcp.io)) is a system performance analysis toolkit.
 
 ## Usage
@@ -33,7 +34,7 @@ $ sudo podman run -d \
 
 ## Configuration
 
-### Environment Variables
+### Environment variables
 
 #### `PCP_SERVICES`
 Default: `pmcd,pmie,pmlogger,pmproxy`
@@ -51,7 +52,7 @@ Default: `localhost:6379`
 Redis connection spec(s) - could be any individual cluster host, and all hosts in the cluster will be automatically discovered.
 Alternately, use comma-separated hostspecs (non-clustered setup)
 
-### Configuration Files
+### Configuration files
 
 For custom configuration options beyond the above environment variables, it is advised to use a bind mount with a configuration file on the host to the container.
 Example command to run a pmlogger-only container:

--- a/src/bci_build/package/registry/README.md.j2
+++ b/src/bci_build/package/registry/README.md.j2
@@ -1,6 +1,12 @@
-# The SLE BCI Distribution Image
+# {{ image.title }}: Suitable for running a local OCI registry
 {% include 'badges.j2' %}
-This container image allows to run a local OCI registry. Before you start the container,
+
+## Description
+This container image allows to run a local OCI registry.
+
+
+## Usage
+Before you start the container,
 you need to create a `config.yml` with the following content:
 
 ```yaml

--- a/src/bci_build/package/spack/README.md.j2
+++ b/src/bci_build/package/spack/README.md.j2
@@ -1,6 +1,7 @@
 # Spack %%spack_version%% Container Image
 {% include 'badges.j2' %}
 
+## Description
 Spack is a package manager for supercomputers. It provides build recipes
 for more than 6000 software components, and it allows to build entire
 HPC application stacks with little to no prerequisites.
@@ -10,8 +11,7 @@ or an `apptainter.def` file created by `spack containerize`. It can be
 used to run spack commands directly as well. Doing this may require to
 bind-mount local directories into the container.
 
-## How to use the image
-
+## Usage
 This image may be used to build and containerize application stacks using
 Spack. The stack is installed in a base container such as SLE BCI Base.
 To build a containerized application stack, create the file `spack.yaml`

--- a/src/bci_build/package/templates/access_protected_images.j2
+++ b/src/bci_build/package/templates/access_protected_images.j2
@@ -1,4 +1,4 @@
-## Accessing the Container Image
+## Accessing the container image
 
 Accessing this container image requires a valid SUSE subscription. In order
 to access the container image, you must login to the SUSE Registry with your credentials.

--- a/src/bci_build/package/tomcat/README.md.j2
+++ b/src/bci_build/package/tomcat/README.md.j2
@@ -1,14 +1,14 @@
 # Tomcat {{ image.version }} Container Image
 {% include 'badges.j2' %}
 
+## Description
 Apache Tomcat (Tomcat for short) is a free and open-source implementation of the
 Jakarta Servlet, Jakarta Expression Language, and WebSocket technologies. It
 provides a pure Java HTTP web server environment that can run Java code. It is a
 Java web application server and not a complete JEE application server.
 
 
-## How to use the image
-
+## Usage
 By default, the image launches Tomcat with the same configuration as the one
 that comes with SUSE Linux Enterprise Server. The difference is that logging is
 sent to stdout, meaning that the `podman logs tomcat` command displays Tomcat


### PR DESCRIPTION
Start with a "Description" and then have a "Usage" section. Remove hardcoded distro references as they make the openSUSE images less confusing.