### PR TITLE
node: Add findutils into the development containers

### DIFF
--- a/src/bci_build/package/node.py
+++ b/src/bci_build/package/node.py
@@ -41,6 +41,8 @@ def _get_node_kwargs(ver: _NODE_VERSIONS, os_version: OsVersion):
             # devel dependencies:
             f"npm{ver}",
             "git-core",
+            # used by upstream installation scripts
+            "findutils",
             # dependency of nodejs:
             "update-alternatives",
         ],


### PR DESCRIPTION
This is used by several popular upstream repos like react and others during installation time. It was implicitly installed beforehand and now the dependency was removed, so we need to install it explicitly.