### PR TITLE
Add findutils to PHPIZE_DEPS

### DIFF
--- a/src/bci_build/package/php.py
+++ b/src/bci_build/package/php.py
@@ -162,7 +162,7 @@ EXPOSE 9000
         env={
             "PHP_VERSION": "%%php_version%%",
             "PHP_INI_DIR": f"/etc/php{php_version}/",
-            "PHPIZE_DEPS": f"php{php_version}-devel awk make",
+            "PHPIZE_DEPS": f"php{php_version}-devel awk make findutils",
             "COMPOSER_VERSION": "%%composer_version%%",
             **extra_env,
         },


### PR DESCRIPTION
Find is often required to install PECL extensions and is no longer in the Tumbleweed base image