### PR TITLE
Add forgotten r to php Dockerfile string

### DIFF
--- a/src/bci_build/package/php.py
+++ b/src/bci_build/package/php.py
@@ -94,7 +94,7 @@ EXPOSE 80
             + DOCKERFILE_RUN
             + rf""" \
 	cd /etc/php{php_version}/fpm/; \ """
-            + """
+            + r"""
         test -e php-fpm.d/www.conf.default && cp -p php-fpm.d/www.conf.default php-fpm.d/www.conf; \
         test -e php-fpm.conf.default && cp -p php-fpm.conf.default php-fpm.conf; \
 	{ \


### PR DESCRIPTION
Without it, the \ before a line end gets converted into a real line end and Dockerfile becomes unreadable