### PR TITLE
Use the bci-ci image for update-versions Github action

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   update-files:
     runs-on: ubuntu-latest
+    container: ghcr.io/dcermak/bci-ci:latest
     steps:
       - name: checkout source code
         uses: actions/checkout@v4
@@ -15,7 +16,11 @@ jobs:
           path: ~/.cache/pypoetry/virtualenvs
           key: poetry-${{ hashFiles('poetry.lock') }}
 
-      - run: poetry install
+      - name: fix the file permissions of the repository
+        run: chown -R $(id -un):$(id -gn) .
+
+      - name: install python dependencies
+        run: poetry install
 
       - name: run version update
         run: poetry run update-versions


### PR DESCRIPTION
Otherwise poetry is not present on the worker and leads to failures like: https://github.com/SUSE/BCI-dockerfile-generator/actions/runs/9392889199/job/25867946179