### PR TITLE
Update the go description to be more along the lines of the existing

### DIFF
--- a/src/bci_build/package/golang/README.md.j2
+++ b/src/bci_build/package/golang/README.md.j2
@@ -23,9 +23,19 @@ library, for cryptographic operations in the container environment.
 
 
 ## Usage
+There are two ways to work with Go images. First, you can encapsulate your
+application in a `scratch` container image, which is essentially an empty
+image. This approach will not function if your Go application depends on libc
+or any other library, as they will not be available.
+
+A second method is to use a slim base container image with just the minimal
+packages needed.
 
 To compile and deploy an application, copy the sources, fetch dependencies
-(assuming go.mod is used for dependency management), and build the binary:
+(assuming go.mod is used for dependency management), and build the binary using
+the following Dockerfile options.
+
+### Building from `scratch`
 
 ```Dockerfile
 # Build the application using the {{ image.pretty_name }} container image
@@ -42,7 +52,7 @@ COPY . ./
 
 # Make sure to build the application with CGO disabled.
 # This will force Go to use some Go implementations of code
-# rather than those normally supplied by the host operating system.
+# rather than those supplied by the host operating system.
 # You need this for scratch images as those supporting libraries
 # are not available.
 RUN CGO_ENABLED=0 go build -o /hello
@@ -76,21 +86,46 @@ To run the application tests inside a container, use the following command:
 $ podman run --rm -v "$PWD":/app:Z -w /app {{ image.pretty_reference }} go test -v
 ```
 
-**Note:** The Go image should be used as a build environment. That means
+### Building from SLE BCI
+
+The Go image should be used as a build environment. That means
 the compiler does not need to be shipped as part of the images that are
 distributed. Instead, it is recommended that the Go image is used as the
 builder image only.
 
-There are two ways to work with Go images. First, you can encapsulate your
-application in a `scratch` container image, which is essentially an empty
-image. This approach will not function if your Go application depends on libc
-or any other library, as they will not be available.
-
-A second method is to use a slim base container image with just the minimal
-packages needed.
 The [SLE BCI General Purpose Base Containers](https://opensource.suse.com/bci-docs/documentation/general-purpose-bci/)
 images offer four different options here, depending on your exact requirements.
 
+```Dockerfile
+# Build the application using the {{ image.pretty_name }} Container Image
+FROM {{ image.pretty_reference }} as build
+
+WORKDIR /app
+
+# pre-copy/cache go.mod for pre-downloading dependencies and only
+# redownloading them in subsequent builds if they change
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+
+COPY . ./
+
+# Make sure to build the application with CGO disabled.
+# This will force Go to use some Go implementations of code
+# rather than those normally supplied by the host operating system.
+# You need this for scratch images as those supporting libraries
+# are not available.
+RUN CGO_ENABLED=0 go build -o /hello
+
+# Bundle the application into a scratch image
+FROM registry.suse.com/bci/bci-micro:15.4
+
+COPY --from=build /hello /hello
+
+CMD ["/hello"]
+```
+
+
+The above example uses the SLE BCI micro image as the deployment image for the resulting application.
 See the [SLE BCI use with Go documentation](https://opensource.suse.com/bci-docs/guides/use-with-golang/)
 for further details.
 

--- a/src/bci_build/package/golang/README.md.j2
+++ b/src/bci_build/package/golang/README.md.j2
@@ -4,11 +4,27 @@
 
 ## Description
 
-[Go](https://go.dev/) (a.k.a., Golang) is a statically-typed programming language, with syntax loosely derived from C. Go offers additional features such as garbage collection, type safety, certain dynamic-typing capabilities, additional built-in types (for example, variable-length arrays and key-value maps) as well as a large standard library.
+[Go](https://go.dev/) (a.k.a., Golang) is a statically-typed programming
+language, with syntax loosely derived from C. Go offers additional features
+such as garbage collection, type safety, certain dynamic-typing capabilities,
+additional built-in types (for example, variable-length arrays and key-value
+maps) as well as a large standard library.
+
+{%- if image.version.endswith('-openssl') %}
+
+## FIPS 140-2
+
+The image includes a FIPS 140-2 enabled Go wrapper that prefers using OpenSSL
+for cryptographic operations. This allows the use of FIPS 140-2 validated
+routines for cryptographic operations in the container environment.
+
+{%- endif %}
+
 
 ## Usage
 
-To compile and deploy an application, copy the sources, fetch dependencies (assuming go.mod is used for dependency management), and build the binary:
+To compile and deploy an application, copy the sources, fetch dependencies
+(assuming go.mod is used for dependency management), and build the binary:
 
 ```Dockerfile
 # Build the application using the {{ image.pretty_name }} container image
@@ -16,7 +32,8 @@ FROM {{ image.pretty_reference }} as build
 
 WORKDIR /app
 
-# pre-copy/cache go.mod for pre-downloading dependencies and only redownloading them in subsequent builds if they change
+# pre-copy/cache go.mod for pre-downloading dependencies and only
+# redownloading them in subsequent builds if they change
 COPY go.mod go.sum ./
 RUN go mod download && go mod verify
 
@@ -58,26 +75,44 @@ To run the application tests inside a container, use the following command:
 $ podman run --rm -v "$PWD":/app:Z -w /app {{ image.pretty_reference }} go test -v
 ```
 
-**Note:** The Golang image should be used as a build environment. For runtime, self-contained Go binaries should use a `scratch` image and for applications that require external dependencies use the `bci-base` image.
+**Note:** The Go image should be used as a build environment. That means
+the compiler does not need to be shipped as part of the images that are
+distributed. Instead, it is recommended that the Go image is used as the
+builder image only.
 
-## Additional tools
+There are two ways to work with Go images. First, you can encapsulate your
+application in a `scratch` container image, which is essentially an empty
+image. This approach will not function if your Go application depends on libc
+or any other library, as they will not be available.
 
-The following additional tools are included in the image:
+A second method is to use a slim base container image with just the minimal
+packages needed.
+The [SLE BCI General Purpose Base Containers](https://opensource.suse.com/bci-docs/documentation/general-purpose-bci/)
+images offer four different options here, depending on your exact requirements.
 
-- go{{ image.version }}-race
-- make
-- git-core
+See the [SLE BCI use with Go documentation](https://opensource.suse.com/bci-docs/guides/use-with-golang/)
+for further details.
 
-{% if image.version.endswith('-openssl') %}
-## FIPS 140
+{%- if image.version.endswith('-openssl') %}
 
-The image includes a FIPS 140 enabled Go toolchain using OpenSSL.
+## FIPS 140-2
 
-To restrict all TLS configuration to FIPS-approved settings, add the following line:
+To restrict all TLS configuration to FIPS-approved settings, add
+the following line:
 
 ```go
 import _ "crypto/tls/fipsonly"
 ```
-{% endif %}
+
+{%- endif %}
+
+
+## Additional tools
+
+The following tools are also included in the image:
+
+- go{{ image.version }}-race
+- make
+- git-core
 
 {% include 'licensing_and_eula.j2' %}

--- a/src/bci_build/package/golang/README.md.j2
+++ b/src/bci_build/package/golang/README.md.j2
@@ -12,11 +12,12 @@ maps) as well as a large standard library.
 
 {%- if image.version.endswith('-openssl') %}
 
-## FIPS 140-2
+## FIPS 140-3
 
-The image includes a FIPS 140-2 enabled Go wrapper that prefers using OpenSSL
-for cryptographic operations. This allows the use of FIPS 140-2 validated
-routines for cryptographic operations in the container environment.
+The image includes a FIPS 140-2/140-3 enabled Go wrapper that prefers using OpenSSL
+for cryptographic operations, if available at runtime.
+This allows the use of FIPS 140-2/140-3 validated routines, provided by the OpenSSL
+library, for cryptographic operations in the container environment.
 
 {%- endif %}
 
@@ -95,7 +96,7 @@ for further details.
 
 {%- if image.version.endswith('-openssl') %}
 
-## FIPS 140-2
+## FIPS 140-3
 
 To restrict all TLS configuration to FIPS-approved settings, add
 the following line:

--- a/src/bci_build/package/golang/README.md.j2
+++ b/src/bci_build/package/golang/README.md.j2
@@ -16,24 +16,30 @@ maps) as well as a large standard library.
 
 The image includes a FIPS 140-2/140-3 enabled Go wrapper that prefers using OpenSSL
 for cryptographic operations, if available at runtime.
-This allows the use of FIPS 140-2/140-3 validated routines, provided by the OpenSSL
+Therefore, you can use FIPS 140-2/140-3 validated routines, provided by the OpenSSL
 library, for cryptographic operations in the container environment.
 
 {%- endif %}
 
 
 ## Usage
-There are two ways to work with Go images. First, you can encapsulate your
-application in a `scratch` container image, which is essentially an empty
-image. This approach will not function if your Go application depends on libc
-or any other library, as they will not be available.
+We recommend using the Go image as a build environment. Thus,  
+the compiler does not need to be shipped as part of the images that are
+deployed. Instead, we recommend to use the Go image as the
+builder image only.
 
-A second method is to use a slim base container image with just the minimal
-packages needed.
+There are two options to work with Go images. First, you can encapsulate your
+application in a `scratch` container image, essentially an empty filesystem
+image. This approach only works if your Go application does not depend on libc
+or any other library or files, as they will not be available.
+
+The second option uses a slim base container image with just the minimal
+packages required to run the Go application.
 
 To compile and deploy an application, copy the sources, fetch dependencies
 (assuming go.mod is used for dependency management), and build the binary using
 the following Dockerfile options.
+
 
 ### Building from `scratch`
 
@@ -60,9 +66,9 @@ RUN CGO_ENABLED=0 go build -o /hello
 # Bundle the application into a scratch image
 FROM scratch
 
-COPY --from=build /hello /hello
+COPY --from=build /hello /usr/local/bin/hello
 
-CMD ["/hello"]
+CMD ["/usr/local/bin/hello"]
 ```
 
 Build and run the container image:
@@ -86,15 +92,11 @@ To run the application tests inside a container, use the following command:
 $ podman run --rm -v "$PWD":/app:Z -w /app {{ image.pretty_reference }} go test -v
 ```
 
+
 ### Building from SLE BCI
 
-The Go image should be used as a build environment. That means
-the compiler does not need to be shipped as part of the images that are
-distributed. Instead, it is recommended that the Go image is used as the
-builder image only.
-
 The [SLE BCI General Purpose Base Containers](https://opensource.suse.com/bci-docs/documentation/general-purpose-bci/)
-images offer four different options here, depending on your exact requirements.
+images offer four different options for deployment, depending on your exact requirements.
 
 ```Dockerfile
 # Build the application using the {{ image.pretty_name }} Container Image
@@ -109,24 +111,19 @@ RUN go mod download && go mod verify
 
 COPY . ./
 
-# Make sure to build the application with CGO disabled.
-# This will force Go to use some Go implementations of code
-# rather than those normally supplied by the host operating system.
-# You need this for scratch images as those supporting libraries
-# are not available.
-RUN CGO_ENABLED=0 go build -o /hello
+RUN go build -o /hello
 
 # Bundle the application into a scratch image
 FROM registry.suse.com/bci/bci-micro:15.4
 
-COPY --from=build /hello /hello
+COPY --from=build /hello /usr/local/bin/hello
 
-CMD ["/hello"]
+CMD ["/usr/local/bin/hello"]
 ```
 
-
-The above example uses the SLE BCI micro image as the deployment image for the resulting application.
-See the [SLE BCI use with Go documentation](https://opensource.suse.com/bci-docs/guides/use-with-golang/)
+The above example uses the SLE BCI micro image as the deployment image for
+the resulting application. See the [SLE BCI use with Go
+documentation](https://opensource.suse.com/bci-docs/guides/use-with-golang/)
 for further details.
 
 {%- if image.version.endswith('-openssl') %}


### PR DESCRIPTION
golang documentation

Also move the FIPS 140-2 section into the description.