### PR TITLE
Reuse the original comment from the gh action bot and don't create new comments

### DIFF
--- a/.github/workflows/obs_build.yml
+++ b/.github/workflows/obs_build.yml
@@ -100,6 +100,8 @@ jobs:
         uses: peter-evans/create-or-update-comment@v4
         id: create_comment
         with:
+          comment-id: ${{ steps.find_comment.outputs.comment-id || '' }}
+          edit-mode: replace
           issue-number: ${{ github.event.pull_request.number }}
           # !!! if you change the body, then you must adjust StagingBot.from_github_comment() !!!
           body: |


### PR DESCRIPTION
Since we now stopped creating a new branch per new build, there's really absolutely no need to create new comments. It just needlessly spams the PR sending out notifications to everyone.