### PR TITLE
Remove rmt nginx from SP7 & Tumbleweed

### DIFF
--- a/src/bci_build/package/appcontainers.py
+++ b/src/bci_build/package/appcontainers.py
@@ -379,7 +379,7 @@ NGINX_CONTAINERS = [
         pretty_name="NGINX for SUSE RMT",
         **_get_nginx_kwargs(os_version),
     )
-    for os_version in ALL_NONBASE_OS_VERSIONS
+    for os_version in (OsVersion.SP5, OsVersion.SP6)
 ] + [
     ApplicationStackContainer(
         name="nginx",


### PR DESCRIPTION
The helm chart has been switched to use nginx-image, we don't need  to provide the backward compatible/legacy rmt-nginx-image anymore.