### PR TITLE
Add minor versions to Prometheus, Blackbox & Alertmanager containers

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -272,7 +272,13 @@ class Package:
         return self.name
 
 
-PARSE_VERSION_T = Literal["major", "minor", "patch", "patch_update", "offset"]
+@enum.unique
+class ParseVersion(enum.StrEnum):
+    MAJOR = enum.auto()
+    MINOR = enum.auto()
+    PATCH = enum.auto()
+    PATCH_UPDATE = enum.auto()
+    OFFSET = enum.auto()
 
 
 @dataclass
@@ -294,7 +300,7 @@ class Replacement:
     #: specify how the version should be formated, see
     #: `<https://github.com/openSUSE/obs-service-replace_using_package_version#usage>`_
     #: for further details
-    parse_version: None | PARSE_VERSION_T = None
+    parse_version: None | ParseVersion = None
 
     def __post_init__(self) -> None:
         """Barf if someone tries to replace variables in README, as those
@@ -302,6 +308,7 @@ class Replacement:
         source package.
 
         """
+
         if self.file_name and "readme" in self.file_name.lower():
             raise ValueError(f"Cannot replace variables in {self.file_name}!")
 

--- a/src/bci_build/package/appcontainers.py
+++ b/src/bci_build/package/appcontainers.py
@@ -203,7 +203,7 @@ HEALTHCHECK --interval=10s --start-period=10s --timeout=5s \
     + [(pg_ver, OsVersion.TUMBLEWEED) for pg_ver in (14, 13, 12)]
 ]
 
-PROMETHEUS_PACKAGE_NAME = "golang-github-prometheus-prometheus"
+_PROMETHEUS_PACKAGE_NAME = "golang-github-prometheus-prometheus"
 PROMETHEUS_CONTAINERS = [
     ApplicationStackContainer(
         package_name="prometheus-image",
@@ -211,16 +211,21 @@ PROMETHEUS_CONTAINERS = [
         is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
         name="prometheus",
         pretty_name="Prometheus",
-        package_list=[PROMETHEUS_PACKAGE_NAME],
-        version="%%prometheus_version%%",
+        package_list=[_PROMETHEUS_PACKAGE_NAME],
+        version="%%prometheus_patch_version%%",
+        additional_versions=[
+            "%%prometheus_minor_version%%",
+            "%%prometheus_major_version%%",
+        ],
         version_in_uid=False,
         entrypoint=["/usr/bin/prometheus"],
         replacements_via_service=[
             Replacement(
-                regex_in_build_description="%%prometheus_version%%",
-                package_name=PROMETHEUS_PACKAGE_NAME,
-                parse_version="patch",
+                regex_in_build_description=f"%%prometheus_{level}_version%%",
+                package_name=_PROMETHEUS_PACKAGE_NAME,
+                parse_version=level,
             )
+            for level in ("major", "minor", "patch")
         ],
         volumes=["/var/lib/prometheus"],
         exposes_tcp=[9090],
@@ -228,7 +233,7 @@ PROMETHEUS_CONTAINERS = [
     for os_version in ALL_NONBASE_OS_VERSIONS
 ]
 
-ALERTMANAGER_PACKAGE_NAME = "golang-github-prometheus-alertmanager"
+_ALERTMANAGER_PACKAGE_NAME = "golang-github-prometheus-alertmanager"
 ALERTMANAGER_CONTAINERS = [
     ApplicationStackContainer(
         package_name="alertmanager-image",
@@ -236,16 +241,18 @@ ALERTMANAGER_CONTAINERS = [
         is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
         name="alertmanager",
         pretty_name="Alertmanager",
-        package_list=[ALERTMANAGER_PACKAGE_NAME],
-        version="%%alertmanager_version%%",
+        package_list=[_ALERTMANAGER_PACKAGE_NAME],
+        version="%%alertmanager_patch_version%%",
+        additional_versions=["%%alertmanager_minor_version%%"],
         version_in_uid=False,
         entrypoint=["/usr/bin/prometheus-alertmanager"],
         replacements_via_service=[
             Replacement(
-                regex_in_build_description="%%alertmanager_version%%",
-                package_name=ALERTMANAGER_PACKAGE_NAME,
-                parse_version="patch",
+                regex_in_build_description=f"%%alertmanager_{level}_version%%",
+                package_name=_ALERTMANAGER_PACKAGE_NAME,
+                parse_version=level,
             )
+            for level in ("minor", "patch")
         ],
         volumes=["/var/lib/prometheus/alertmanager"],
         exposes_tcp=[9093],
@@ -253,7 +260,7 @@ ALERTMANAGER_CONTAINERS = [
     for os_version in ALL_NONBASE_OS_VERSIONS
 ]
 
-BLACKBOX_EXPORTER_PACKAGE_NAME = "prometheus-blackbox_exporter"
+_BLACKBOX_EXPORTER_PACKAGE_NAME = "prometheus-blackbox_exporter"
 BLACKBOX_EXPORTER_CONTAINERS = [
     ApplicationStackContainer(
         package_name="blackbox_exporter-image",
@@ -261,29 +268,31 @@ BLACKBOX_EXPORTER_CONTAINERS = [
         is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
         name="blackbox_exporter",
         pretty_name="Blackbox Exporter",
-        package_list=[BLACKBOX_EXPORTER_PACKAGE_NAME],
-        version="%%blackbox_exporter_version%%",
+        package_list=[_BLACKBOX_EXPORTER_PACKAGE_NAME],
+        version="%%blackbox_exporter_patch_version%%",
+        additional_versions=["%%blackbox_exporter_minor_version%%"],
         version_in_uid=False,
         entrypoint=["/usr/bin/blackbox_exporter"],
         replacements_via_service=[
             Replacement(
-                regex_in_build_description="%%blackbox_exporter_version%%",
-                package_name=BLACKBOX_EXPORTER_PACKAGE_NAME,
-                parse_version="patch",
+                regex_in_build_description=f"%%blackbox_exporter_{level}_version%%",
+                package_name=_BLACKBOX_EXPORTER_PACKAGE_NAME,
+                parse_version=level,
             )
+            for level in ("minor", "patch")
         ],
         exposes_tcp=[9115],
     )
     for os_version in ALL_NONBASE_OS_VERSIONS
 ]
 
-GRAFANA_FILES = {}
+_GRAFANA_FILES = {}
 for filename in ("run.sh", "LICENSE"):
-    GRAFANA_FILES[filename] = (
+    _GRAFANA_FILES[filename] = (
         Path(__file__).parent / "grafana" / filename
     ).read_bytes()
 
-GRAFANA_PACKAGE_NAME = "grafana"
+_GRAFANA_PACKAGE_NAME = "grafana"
 GRAFANA_CONTAINERS = [
     ApplicationStackContainer(
         package_name="grafana-image",
@@ -292,11 +301,12 @@ GRAFANA_CONTAINERS = [
         name="grafana",
         pretty_name="Grafana",
         license="Apache-2.0",
-        package_list=[GRAFANA_PACKAGE_NAME],
-        version="%%grafana_version%%",
+        package_list=[_GRAFANA_PACKAGE_NAME],
+        version="%%grafana_patch_version%%",
+        additional_versions=["%%grafana_minor_version%%", "%%grafana_major_version%%"],
         version_in_uid=False,
         entrypoint=["/run.sh"],
-        extra_files=GRAFANA_FILES,
+        extra_files=_GRAFANA_FILES,
         env={
             "GF_PATHS_DATA": "/var/lib/grafana",
             "GF_PATHS_HOME": "/usr/share/grafana",
@@ -306,10 +316,11 @@ GRAFANA_CONTAINERS = [
         },
         replacements_via_service=[
             Replacement(
-                regex_in_build_description="%%grafana_version%%",
-                package_name=GRAFANA_PACKAGE_NAME,
-                parse_version="patch",
+                regex_in_build_description=f"%%grafana_{level}_version%%",
+                package_name=_GRAFANA_PACKAGE_NAME,
+                parse_version=level,
             )
+            for level in ("major", "minor", "patch")
         ],
         volumes=["/var/lib/grafana"],
         exposes_tcp=[3000],

--- a/src/bci_build/package/appcontainers.py
+++ b/src/bci_build/package/appcontainers.py
@@ -13,6 +13,7 @@ from bci_build.package import OsContainer
 from bci_build.package import OsVersion
 from bci_build.package import Package
 from bci_build.package import PackageType
+from bci_build.package import ParseVersion
 from bci_build.package import Replacement
 from bci_build.package import SupportLevel
 from bci_build.package import _build_tag_prefix
@@ -60,7 +61,7 @@ PCP_CONTAINERS = [
                 package_name="pcp",
                 parse_version=ver,
             )
-            for ver in ("major", "minor")
+            for ver in (ParseVersion.MAJOR, ParseVersion.MINOR)
         ],
         license="(LGPL-2.1+ AND GPL-2.0+)",
         package_list=[
@@ -116,7 +117,7 @@ THREE_EIGHT_NINE_DS_CONTAINERS = [
             Replacement(
                 regex_in_build_description="%%389ds_version%%",
                 package_name="389-ds",
-                parse_version="minor",
+                parse_version=ParseVersion.MINOR,
             )
         ],
         exposes_tcp=[3389, 3636],
@@ -175,7 +176,7 @@ POSTGRES_CONTAINERS = [
             Replacement(
                 regex_in_build_description="%%pg_version%%",
                 package_name=f"postgresql{ver}-server",
-                parse_version="minor",
+                parse_version=ParseVersion.MINOR,
             )
         ],
         volumes=["$PGDATA"],
@@ -225,7 +226,7 @@ PROMETHEUS_CONTAINERS = [
                 package_name=_PROMETHEUS_PACKAGE_NAME,
                 parse_version=level,
             )
-            for level in ("major", "minor", "patch")
+            for level in (ParseVersion.MAJOR, ParseVersion.MINOR, ParseVersion.PATCH)
         ],
         volumes=["/var/lib/prometheus"],
         exposes_tcp=[9090],
@@ -252,7 +253,7 @@ ALERTMANAGER_CONTAINERS = [
                 package_name=_ALERTMANAGER_PACKAGE_NAME,
                 parse_version=level,
             )
-            for level in ("minor", "patch")
+            for level in (ParseVersion.MINOR, ParseVersion.PATCH)
         ],
         volumes=["/var/lib/prometheus/alertmanager"],
         exposes_tcp=[9093],
@@ -279,7 +280,7 @@ BLACKBOX_EXPORTER_CONTAINERS = [
                 package_name=_BLACKBOX_EXPORTER_PACKAGE_NAME,
                 parse_version=level,
             )
-            for level in ("minor", "patch")
+            for level in (ParseVersion.MINOR, ParseVersion.PATCH)
         ],
         exposes_tcp=[9115],
     )
@@ -320,7 +321,7 @@ GRAFANA_CONTAINERS = [
                 package_name=_GRAFANA_PACKAGE_NAME,
                 parse_version=level,
             )
-            for level in ("major", "minor", "patch")
+            for level in (ParseVersion.MAJOR, ParseVersion.MINOR, ParseVersion.PATCH)
         ],
         volumes=["/var/lib/grafana"],
         exposes_tcp=[3000],
@@ -356,7 +357,7 @@ def _get_nginx_kwargs(os_version: OsVersion):
             Replacement(
                 regex_in_build_description="%%nginx_version%%",
                 package_name="nginx",
-                parse_version="minor",
+                parse_version=ParseVersion.MINOR,
             )
         ],
         "package_list": ["gawk", "nginx", "findutils", _envsubst_pkg_name(os_version)],
@@ -419,7 +420,7 @@ GIT_CONTAINERS = [
             Replacement(
                 regex_in_build_description="%%git_version%%",
                 package_name="git-core",
-                parse_version="minor",
+                parse_version=ParseVersion.MINOR,
             )
         ],
         license="GPL-2.0-only",
@@ -453,7 +454,7 @@ REGISTRY_CONTAINERS = [
             Replacement(
                 regex_in_build_description="%%registry_version%%",
                 package_name="distribution-registry",
-                parse_version="minor",
+                parse_version=ParseVersion.MINOR,
             )
         ],
         license="Apache-2.0",
@@ -493,7 +494,7 @@ HELM_CONTAINERS = [
             Replacement(
                 regex_in_build_description="%%helm_version%%",
                 package_name="helm",
-                parse_version="minor",
+                parse_version=ParseVersion.MINOR,
             )
         ],
         license="Apache-2.0",
@@ -527,7 +528,7 @@ TRIVY_CONTAINERS = [
             Replacement(
                 regex_in_build_description="%%trivy_version%%",
                 package_name="trivy",
-                parse_version="minor",
+                parse_version=ParseVersion.MINOR,
             )
         ],
         license="Apache-2.0",
@@ -579,7 +580,7 @@ TOMCAT_CONTAINERS = [
             Replacement(
                 regex_in_build_description="%%tomcat_minor%%",
                 package_name=tomcat_pkg,
-                parse_version="minor",
+                parse_version=ParseVersion.MINOR,
             ),
         ],
         cmd=[

--- a/src/bci_build/package/gcc.py
+++ b/src/bci_build/package/gcc.py
@@ -7,6 +7,7 @@ from bci_build.package import CAN_BE_LATEST_OS_VERSION
 from bci_build.package import DOCKERFILE_RUN
 from bci_build.package import DevelopmentContainer
 from bci_build.package import OsVersion
+from bci_build.package import ParseVersion
 from bci_build.package import Replacement
 from bci_build.package import SupportLevel
 from bci_build.package import generate_disk_size_constraints
@@ -77,7 +78,7 @@ GCC_CONTAINERS = [
             Replacement(
                 regex_in_build_description="%%gcc_version%%",
                 package_name=gcc_pkg,
-                parse_version="minor",
+                parse_version=ParseVersion.MINOR,
             )
         ],
         env={"GCC_VERSION": "%%gcc_version%%"},

--- a/src/bci_build/package/helpers.py
+++ b/src/bci_build/package/helpers.py
@@ -1,9 +1,9 @@
 from bci_build.package import DOCKERFILE_RUN
-from bci_build.package import PARSE_VERSION_T
+from bci_build.package import ParseVersion
 
 
 def generate_package_version_check(
-    pkg_name: str, pkg_version: str, parse_version: PARSE_VERSION_T = "minor"
+    pkg_name: str, pkg_version: str, parse_version: ParseVersion = ParseVersion.MINOR
 ) -> str:
     """Generate a RUN instruction for a :file:`Dockerfile` that will fail if the
     package with the name ``pkg_name`` is not at the provided version
@@ -12,7 +12,11 @@ def generate_package_version_check(
     major+minor+patch version.
 
     """
-    cut_count: dict[PARSE_VERSION_T, int] = {"major": 1, "minor": 2, "patch": 3}
+    cut_count: dict[ParseVersion, int] = {
+        ParseVersion.MAJOR: 1,
+        ParseVersion.MINOR: 2,
+        ParseVersion.PATCH: 3,
+    }
 
     return f"""# sanity check that the version from the tag is equal to the version of {pkg_name} that we expect
 {DOCKERFILE_RUN} [ "$(rpm -q --qf '%{{version}}' {pkg_name} | cut -d '.' -f -{cut_count[parse_version]})" = "{pkg_version}" ]"""

--- a/src/bci_build/package/mariadb.py
+++ b/src/bci_build/package/mariadb.py
@@ -9,6 +9,7 @@ from bci_build.package import DOCKERFILE_RUN
 from bci_build.package import ApplicationStackContainer
 from bci_build.package import BuildType
 from bci_build.package import OsVersion
+from bci_build.package import ParseVersion
 from bci_build.package import Replacement
 from bci_build.package import SupportLevel
 from bci_build.package import generate_disk_size_constraints
@@ -81,7 +82,7 @@ for os_version in ALL_NONBASE_OS_VERSIONS:  # + [OsVersion.BASALT]:
                     regex_in_build_description=_MARIADB_VERSION_REGEX,
                     package_name="mariadb",
                     file_name=_ENTRYPOINT_FNAME,
-                    parse_version="patch",
+                    parse_version=ParseVersion.PATCH,
                 )
             ],
             package_list=[

--- a/src/bci_build/package/rmt.py
+++ b/src/bci_build/package/rmt.py
@@ -7,6 +7,7 @@ from bci_build.package import CAN_BE_LATEST_OS_VERSION
 from bci_build.package import DOCKERFILE_RUN
 from bci_build.package import ApplicationStackContainer
 from bci_build.package import BuildType
+from bci_build.package import ParseVersion
 from bci_build.package import Replacement
 
 _RMT_ENTRYPOINT = (Path(__file__).parent / "rmt-server" / "entrypoint.sh").read_bytes()
@@ -25,7 +26,7 @@ RMT_CONTAINERS = [
             Replacement(
                 regex_in_build_description="%%rmt_version%%",
                 package_name="rmt-server",
-                parse_version="minor",
+                parse_version=ParseVersion.MINOR,
             )
         ],
         version_in_uid=False,

--- a/src/bci_build/package/ruby.py
+++ b/src/bci_build/package/ruby.py
@@ -5,6 +5,7 @@ from typing import Literal
 from bci_build.package import CAN_BE_LATEST_OS_VERSION
 from bci_build.package import DevelopmentContainer
 from bci_build.package import OsVersion
+from bci_build.package import ParseVersion
 from bci_build.package import Replacement
 from bci_build.package import SupportLevel
 from bci_build.package import generate_disk_size_constraints
@@ -33,7 +34,7 @@ def _get_ruby_kwargs(ruby_version: Literal["2.5", "3.3"], os_version: OsVersion)
             Replacement(
                 regex_in_build_description="%%rb_maj%%",
                 package_name=ruby,
-                parse_version="minor",
+                parse_version=ParseVersion.MINOR,
             ),
         ],
         "package_list": [

--- a/src/bci_build/package/spack.py
+++ b/src/bci_build/package/spack.py
@@ -6,6 +6,7 @@ from bci_build.package import _SUPPORTED_UNTIL_SLE
 from bci_build.package import Arch
 from bci_build.package import DevelopmentContainer
 from bci_build.package import OsVersion
+from bci_build.package import ParseVersion
 from bci_build.package import Replacement
 from bci_build.package import SupportLevel
 from bci_build.package import generate_disk_size_constraints
@@ -28,7 +29,7 @@ SPACK_CONTAINERS = [
             Replacement(
                 regex_in_build_description="%%spack_minor%%",
                 package_name="spack",
-                parse_version="minor",
+                parse_version=ParseVersion.MINOR,
             ),
         ],
         package_list=[

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,6 +1,7 @@
 from bci_build.package import BuildType
 from bci_build.package import DevelopmentContainer
 from bci_build.package import OsVersion
+from bci_build.package import ParseVersion
 from bci_build.package import Replacement
 from bci_build.templates import SERVICE_TEMPLATE
 
@@ -74,13 +75,13 @@ def test_service_with_replacement_docker():
                     Replacement(
                         regex_in_build_description="%%minor_ver%%",
                         package_name="filesystem",
-                        parse_version="minor",
+                        parse_version=ParseVersion.MINOR,
                     ),
                     Replacement(
                         regex_in_build_description="%%minor_ver%%",
                         file_name="replacementfile",
                         package_name="filesystem",
-                        parse_version="minor",
+                        parse_version=ParseVersion.MINOR,
                     ),
                 ],
             )


### PR DESCRIPTION
This will no longer require to hardcode patch versions in https://github.com/SUSE/BCI-tests/pull/503 and allow us to resort to minor or major versions