### PR TITLE
Mark SLE15 SP6 as latest, remove SP5 overlap containers

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -241,7 +241,6 @@ RELEASED_OS_VERSIONS: list[OsVersion] = [
 
 # For which versions to create Application and Language Containers?
 ALL_NONBASE_OS_VERSIONS: list[OsVersion] = [
-    OsVersion.SP5,
     OsVersion.SP6,
     OsVersion.TUMBLEWEED,
 ]
@@ -263,7 +262,7 @@ ALL_OS_VERSIONS: set[OsVersion] = {
 }
 
 CAN_BE_LATEST_OS_VERSION: list[OsVersion] = [
-    OsVersion.SP5,
+    OsVersion.SP6,
     OsVersion.TUMBLEWEED,
     OsVersion.BASALT,
 ]

--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -190,6 +190,10 @@ class OsVersion(enum.Enum):
         )
 
     @property
+    def is_tumbleweed(self) -> bool:
+        return self.value == OsVersion.TUMBLEWEED.value
+
+    @property
     def os_version(self) -> str:
         """Returns the numeric version of :py:class:`OsContainer` (or
         ``latest``).

--- a/src/bci_build/package/appcontainers.py
+++ b/src/bci_build/package/appcontainers.py
@@ -3,7 +3,6 @@
 from itertools import product
 from pathlib import Path
 
-from bci_build.package import ALL_BASE_OS_VERSIONS
 from bci_build.package import ALL_NONBASE_OS_VERSIONS
 from bci_build.package import CAN_BE_LATEST_OS_VERSION
 from bci_build.package import DOCKERFILE_RUN
@@ -197,10 +196,7 @@ HEALTHCHECK --interval=10s --start-period=10s --timeout=5s \
     )
     for ver, os_version in (
         [(15, variant) for variant in (OsVersion.SP5, OsVersion.TUMBLEWEED)]
-        + [
-            (16, variant)
-            for variant in (OsVersion.SP5, OsVersion.SP6, OsVersion.TUMBLEWEED)
-        ]
+        + [(16, variant) for variant in (OsVersion.SP6, OsVersion.TUMBLEWEED)]
     )
     + [(pg_ver, OsVersion.TUMBLEWEED) for pg_ver in (14, 13, 12)]
 ]
@@ -406,7 +402,7 @@ NGINX_CONTAINERS = [
         pretty_name="NGINX for SUSE RMT",
         **_get_nginx_kwargs(os_version),
     )
-    for os_version in (OsVersion.SP5, OsVersion.SP6)
+    for os_version in (OsVersion.SP6,)
 ] + [
     ApplicationStackContainer(
         name="nginx",
@@ -615,5 +611,5 @@ WORKDIR $CATALINA_HOME
         entrypoint_user="tomcat",
         logo_url="https://tomcat.apache.org/res/images/tomcat.png",
     )
-    for tomcat_major, os_version in product(_TOMCAT_VERSIONS, ALL_BASE_OS_VERSIONS)
+    for tomcat_major, os_version in product(_TOMCAT_VERSIONS, ALL_NONBASE_OS_VERSIONS)
 ]

--- a/src/bci_build/package/gcc.py
+++ b/src/bci_build/package/gcc.py
@@ -96,8 +96,6 @@ GCC_CONTAINERS = [
         ),
     )
     for (gcc_version, os_version) in (
-        (7, OsVersion.SP5),
-        (13, OsVersion.SP5),
         (7, OsVersion.SP6),
         (13, OsVersion.SP6),
         # (13, OsVersion.SLCC_DEVELOPMENT),

--- a/src/bci_build/package/golang.py
+++ b/src/bci_build/package/golang.py
@@ -86,7 +86,7 @@ GOLANG_CONTAINERS = (
             support_level=SupportLevel.L3,
         )
         for ver, govariant, sle15sp in product(
-            _GOLANG_VERSIONS, ("",), (OsVersion.SP5, OsVersion.SP6)
+            _GOLANG_VERSIONS, ("",), (OsVersion.SP6,)
         )
     ]
     + [
@@ -95,7 +95,7 @@ GOLANG_CONTAINERS = (
             support_level=SupportLevel.L3,
         )
         for ver, govariant, sle15sp in product(
-            _GOLANG_OPENSSL_VERSIONS, ("-openssl",), (OsVersion.SP5, OsVersion.SP6)
+            _GOLANG_OPENSSL_VERSIONS, ("-openssl",), (OsVersion.SP6,)
         )
     ]
     + [

--- a/src/bci_build/package/node.py
+++ b/src/bci_build/package/node.py
@@ -60,9 +60,6 @@ NODE_CONTAINERS = [
         **_get_node_kwargs(18, OsVersion.SP5), support_level=SupportLevel.L3
     ),
     DevelopmentContainer(
-        **_get_node_kwargs(20, OsVersion.SP5), support_level=SupportLevel.L3
-    ),
-    DevelopmentContainer(
         **_get_node_kwargs(20, OsVersion.SP6), support_level=SupportLevel.L3
     ),
     DevelopmentContainer(**_get_node_kwargs(20, OsVersion.TUMBLEWEED)),

--- a/src/bci_build/package/openjdk.py
+++ b/src/bci_build/package/openjdk.py
@@ -4,7 +4,6 @@ import os
 from itertools import product
 from typing import Literal
 
-from bci_build.package import CAN_BE_LATEST_OS_VERSION
 from bci_build.package import DOCKERFILE_RUN
 from bci_build.package import Arch
 from bci_build.package import DevelopmentContainer
@@ -27,7 +26,9 @@ def _get_openjdk_kwargs(
         "JAVA_VERSION": f"{java_version}",
     }
 
-    is_latest = java_version == 17 and os_version in CAN_BE_LATEST_OS_VERSION
+    is_latest = (java_version == 21 and os_version.is_sle15) or (
+        java_version == 22 and os_version.is_tumbleweed
+    )
 
     common = {
         # Hardcoding /usr/lib64 in JAVA_HOME atm

--- a/src/bci_build/package/php.py
+++ b/src/bci_build/package/php.py
@@ -192,7 +192,7 @@ zypper -n in ${{extensions[*]}}
 PHP_CONTAINERS = [
     _create_php_bci(os_version, variant, 8)
     for os_version, variant in product(
-        (OsVersion.SP5, OsVersion.SP6, OsVersion.TUMBLEWEED),
+        (OsVersion.SP6, OsVersion.TUMBLEWEED),
         (PhpVariant.cli, PhpVariant.apache, PhpVariant.fpm),
     )
 ]

--- a/src/bci_build/package/python.py
+++ b/src/bci_build/package/python.py
@@ -100,7 +100,7 @@ PYTHON_3_6_CONTAINERS = (
         **_get_python_kwargs("3.6", os_version),
         package_name="python-3.6-image",
     )
-    for os_version in (OsVersion.SP5, OsVersion.SP6)
+    for os_version in (OsVersion.SP6,)
 )
 
 _PYTHON_TW_VERSIONS: _PYTHON_VERSIONS = ("3.10", "3.12", "3.11")
@@ -119,7 +119,7 @@ PYTHON_3_11_CONTAINERS = (
         package_name="python-3.11-image",
         is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
     )
-    for os_version in (OsVersion.SP5, OsVersion.SP6)
+    for os_version in (OsVersion.SP6,)
 )
 
 PYTHON_3_12_CONTAINERS = PythonDevelopmentContainer(

--- a/src/bci_build/package/ruby.py
+++ b/src/bci_build/package/ruby.py
@@ -65,10 +65,6 @@ def _get_ruby_kwargs(ruby_version: Literal["2.5", "3.3"], os_version: OsVersion)
 
 RUBY_CONTAINERS = [
     DevelopmentContainer(
-        **_get_ruby_kwargs("2.5", OsVersion.SP5),
-        support_level=SupportLevel.L3,
-    ),
-    DevelopmentContainer(
         **_get_ruby_kwargs("2.5", OsVersion.SP6),
         support_level=SupportLevel.L3,
     ),

--- a/src/dotnet/updater.py
+++ b/src/dotnet/updater.py
@@ -369,7 +369,7 @@ def _is_latest_dotnet(version: _DOTNET_VERSION_T, os_version: OsVersion) -> bool
 
 DOTNET_IMAGES: list[DotNetBCI] = []
 
-for os_version in (OsVersion.SP5, OsVersion.SP6):
+for os_version in (OsVersion.SP6,):
     for ver in _DOTNET_VERSIONS:
         package_list: list[Package | str] = [
             "dotnet-host",


### PR DESCRIPTION
This removes creation of SP5 containers for which a SP6 variant exists.