### PR TITLE
Add procps into the pcp container

### DIFF
--- a/src/bci_build/package/appcontainers.py
+++ b/src/bci_build/package/appcontainers.py
@@ -67,6 +67,7 @@ PCP_CONTAINERS = [
         package_list=[
             "pcp",
             "hostname",
+            "procps",
             "shadow",
             _envsubst_pkg_name(os_version),
             "util-linux-systemd",


### PR DESCRIPTION
This probably should be a direct dependency of pcp, but interim we can install it ourselves. without this the performance metrics collector fails with

  Starting Performance Metrics Collector Daemon...
  /etc/pcp.env: line 218: ps: command not found