### PR TITLE
Generate crb yaml config

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -839,6 +839,83 @@ files = [
 ]
 
 [[package]]
+name = "ruamel-yaml"
+version = "0.18.6"
+description = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruamel.yaml-0.18.6-py3-none-any.whl", hash = "sha256:57b53ba33def16c4f3d807c0ccbc00f8a6081827e81ba2491691b76882d0c636"},
+    {file = "ruamel.yaml-0.18.6.tar.gz", hash = "sha256:8b27e6a217e786c6fbe5634d8f3f11bc63e0f80f6a5890f28863d9c45aac311b"},
+]
+
+[package.dependencies]
+"ruamel.yaml.clib" = {version = ">=0.2.7", markers = "platform_python_implementation == \"CPython\" and python_version < \"3.13\""}
+
+[package.extras]
+docs = ["mercurial (>5.7)", "ryd"]
+jinja2 = ["ruamel.yaml.jinja2 (>=0.2)"]
+
+[[package]]
+name = "ruamel-yaml-clib"
+version = "0.2.8"
+description = "C version of reader, parser and emitter for ruamel.yaml derived from libyaml"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b42169467c42b692c19cf539c38d4602069d8c1505e97b86387fcf7afb766e1d"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:07238db9cbdf8fc1e9de2489a4f68474e70dffcb32232db7c08fa61ca0c7c462"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:fff3573c2db359f091e1589c3d7c5fc2f86f5bdb6f24252c2d8e539d4e45f412"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:aa2267c6a303eb483de8d02db2871afb5c5fc15618d894300b88958f729ad74f"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:840f0c7f194986a63d2c2465ca63af8ccbbc90ab1c6001b1978f05119b5e7334"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:024cfe1fc7c7f4e1aff4a81e718109e13409767e4f871443cbff3dba3578203d"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-win32.whl", hash = "sha256:c69212f63169ec1cfc9bb44723bf2917cbbd8f6191a00ef3410f5a7fe300722d"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-win_amd64.whl", hash = "sha256:cabddb8d8ead485e255fe80429f833172b4cadf99274db39abc080e068cbcc31"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bef08cd86169d9eafb3ccb0a39edb11d8e25f3dae2b28f5c52fd997521133069"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:b16420e621d26fdfa949a8b4b47ade8810c56002f5389970db4ddda51dbff248"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:25c515e350e5b739842fc3228d662413ef28f295791af5e5110b543cf0b57d9b"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_24_aarch64.whl", hash = "sha256:1707814f0d9791df063f8c19bb51b0d1278b8e9a2353abbb676c2f685dee6afe"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:46d378daaac94f454b3a0e3d8d78cafd78a026b1d71443f4966c696b48a6d899"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:09b055c05697b38ecacb7ac50bdab2240bfca1a0c4872b0fd309bb07dc9aa3a9"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-win32.whl", hash = "sha256:53a300ed9cea38cf5a2a9b069058137c2ca1ce658a874b79baceb8f892f915a7"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-win_amd64.whl", hash = "sha256:c2a72e9109ea74e511e29032f3b670835f8a59bbdc9ce692c5b4ed91ccf1eedb"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:ebc06178e8821efc9692ea7544aa5644217358490145629914d8020042c24aa1"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:edaef1c1200c4b4cb914583150dcaa3bc30e592e907c01117c08b13a07255ec2"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d176b57452ab5b7028ac47e7b3cf644bcfdc8cacfecf7e71759f7f51a59e5c92"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux_2_24_aarch64.whl", hash = "sha256:1dc67314e7e1086c9fdf2680b7b6c2be1c0d8e3a8279f2e993ca2a7545fecf62"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:3213ece08ea033eb159ac52ae052a4899b56ecc124bb80020d9bbceeb50258e9"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aab7fd643f71d7946f2ee58cc88c9b7bfc97debd71dcc93e03e2d174628e7e2d"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-win32.whl", hash = "sha256:5c365d91c88390c8d0a8545df0b5857172824b1c604e867161e6b3d59a827eaa"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-win_amd64.whl", hash = "sha256:1758ce7d8e1a29d23de54a16ae867abd370f01b5a69e1a3ba75223eaa3ca1a1b"},
+    {file = "ruamel.yaml.clib-0.2.8-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a5aa27bad2bb83670b71683aae140a1f52b0857a2deff56ad3f6c13a017a26ed"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c58ecd827313af6864893e7af0a3bb85fd529f862b6adbefe14643947cfe2942"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_12_0_arm64.whl", hash = "sha256:f481f16baec5290e45aebdc2a5168ebc6d35189ae6fea7a58787613a25f6e875"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_24_aarch64.whl", hash = "sha256:77159f5d5b5c14f7c34073862a6b7d34944075d9f93e681638f6d753606c6ce6"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7f67a1ee819dc4562d444bbafb135832b0b909f81cc90f7aa00260968c9ca1b3"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:4ecbf9c3e19f9562c7fdd462e8d18dd902a47ca046a2e64dba80699f0b6c09b7"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:87ea5ff66d8064301a154b3933ae406b0863402a799b16e4a1d24d9fbbcbe0d3"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-win32.whl", hash = "sha256:75e1ed13e1f9de23c5607fe6bd1aeaae21e523b32d83bb33918245361e9cc51b"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-win_amd64.whl", hash = "sha256:3f215c5daf6a9d7bbed4a0a4f760f3113b10e82ff4c5c44bec20a68c8014f675"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1b617618914cb00bf5c34d4357c37aa15183fa229b24767259657746c9077615"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:a6a9ffd280b71ad062eae53ac1659ad86a17f59a0fdc7699fd9be40525153337"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_24_aarch64.whl", hash = "sha256:305889baa4043a09e5b76f8e2a51d4ffba44259f6b4c72dec8ca56207d9c6fe1"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:700e4ebb569e59e16a976857c8798aee258dceac7c7d6b50cab63e080058df91"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:e2b4c44b60eadec492926a7270abb100ef9f72798e18743939bdbf037aab8c28"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e79e5db08739731b0ce4850bed599235d601701d5694c36570a99a0c5ca41a9d"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-win32.whl", hash = "sha256:955eae71ac26c1ab35924203fda6220f84dce57d6d7884f189743e2abe3a9fbe"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-win_amd64.whl", hash = "sha256:56f4252222c067b4ce51ae12cbac231bce32aee1d33fbfc9d17e5b8d6966c312"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:03d1162b6d1df1caa3a4bd27aa51ce17c9afc2046c31b0ad60a0a96ec22f8001"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:bba64af9fa9cebe325a62fa398760f5c7206b215201b0ec825005f1b18b9bccf"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_24_aarch64.whl", hash = "sha256:a1a45e0bb052edf6a1d3a93baef85319733a888363938e1fc9924cb00c8df24c"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:da09ad1c359a728e112d60116f626cc9f29730ff3e0e7db72b9a2dbc2e4beed5"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:184565012b60405d93838167f425713180b949e9d8dd0bbc7b49f074407c5a8b"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a75879bacf2c987c003368cf14bed0ffe99e8e85acfa6c0bfffc21a090f16880"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-win32.whl", hash = "sha256:84b554931e932c46f94ab306913ad7e11bba988104c5cff26d90d03f68258cd5"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-win_amd64.whl", hash = "sha256:25ac8c08322002b06fa1d49d1646181f0b2c72f5cbc15a85e80b4c30a544bb15"},
+    {file = "ruamel.yaml.clib-0.2.8.tar.gz", hash = "sha256:beb2e0404003de9a4cab9753a8805a8fe9320ee6673136ed7f04255fe60bb512"},
+]
+
+[[package]]
 name = "ruff"
 version = "0.5.2"
 description = "An extremely fast Python linter and code formatter, written in Rust."
@@ -1149,4 +1226,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "a71921797533b1ceef9dbbcf5ba3f83a784f7f1f71072d2791892ad8660ef3ce"
+content-hash = "df6af4b1e6fe0b00dadb79ff0a84268ff58a62f753739a83d7017138ea375d47"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ GitPython = ">=3.1"
 package = "bci_build.package:main"
 scratch-build-bot = "staging.bot:main"
 update-versions = "bci_build.package.versions:run_version_update"
+dump-crb-yaml = "staging.release_bot:dump_data"
 
 [tool.poetry.group.dev.dependencies]
 ruff = ">=0.1.14"
@@ -31,6 +32,7 @@ pytest = ">=7.1"
 types-aiofiles = ">=22.1"
 pytest-asyncio = ">=0.20, != 0.22.0"
 pyyaml = ">=6.0"
+ruamel-yaml = ">=0.18.6"
 
 [tool.ruff.lint]
 select = [

--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -83,6 +83,10 @@ class BuildType(enum.Enum):
     def __str__(self) -> str:
         return self.value
 
+    @property
+    def repository_name(self) -> str:
+        return "containers" if self.value == BuildType.DOCKER.value else "images"
+
 
 @enum.unique
 class SupportLevel(enum.Enum):
@@ -523,6 +527,10 @@ class BaseContainerImage(abc.ABC):
     #: webui sorting)
     _min_release_counter: int | None = None
 
+    #: A custom name for the test environment if it is not equal to the
+    #: container image's name
+    _custom_test_env: str = ""
+
     def __post_init__(self) -> None:
         self.pretty_name = self.pretty_name.strip()
 
@@ -571,6 +579,20 @@ class BaseContainerImage(abc.ABC):
 
         """
         pass
+
+    @property
+    @abc.abstractmethod
+    def test_marker(self) -> str:
+        """The marker used to identify this image in BCI-Tests"""
+        pass
+
+    @property
+    def test_environment(self) -> str:
+        """The test environment name in BCI-Tests corresponding to this
+        container image
+
+        """
+        return self._custom_test_env or self.name
 
     @property
     def build_name(self) -> str | None:
@@ -1307,6 +1329,10 @@ class DevelopmentContainer(BaseContainerImage):
             raise ValueError("A language stack container requires a version")
 
     @property
+    def test_marker(self) -> str:
+        return f"{self.name}_{self.stability_tag or self.version}"
+
+    @property
     def _registry_prefix(self) -> str:
         if self.os_version.is_tumbleweed:
             return "opensuse/bci"
@@ -1455,6 +1481,13 @@ class OsContainer(BaseContainerImage):
         if os_version in (OsVersion.TUMBLEWEED, OsVersion.BASALT):
             return "latest"
         return f"15.{os_version}"
+
+    @property
+    def test_marker(self) -> str:
+        return (
+            f"{self.name}_{OsContainer.version_to_container_os_version(self.os_version)}"
+            + ("-ltss" if self.os_version.is_ltss else "")
+        )
 
     @property
     def uid(self) -> str:

--- a/src/bci_build/package/node.py
+++ b/src/bci_build/package/node.py
@@ -51,6 +51,7 @@ def _get_node_kwargs(ver: _NODE_VERSIONS, os_version: OsVersion):
             "NODE_VERSION": ver,
         },
         "_min_release_counter": 30,
+        "_custom_test_env": "node",
     }
 
 

--- a/src/bci_build/package/openjdk.py
+++ b/src/bci_build/package/openjdk.py
@@ -56,6 +56,7 @@ def _get_openjdk_kwargs(
             "package_list": [f"java-{java_version}-openjdk-devel", "maven"],
             "cmd": ["/usr/bin/jshell"],
             "from_image": f"{_build_tag_prefix(os_version)}/openjdk:{java_version}",
+            "_custom_test_env": "openjdk_devel",
         }
     return common | {
         "name": "openjdk",

--- a/src/bci_build/package/php.py
+++ b/src/bci_build/package/php.py
@@ -187,6 +187,7 @@ zypper -n in ${{extensions[*]}}
         },
         custom_end=custom_end,
         _min_release_counter=30,
+        _custom_test_env="php",
     )
 
 

--- a/src/dotnet/updater.py
+++ b/src/dotnet/updater.py
@@ -210,6 +210,7 @@ class DotNetBCI(DevelopmentContainer):
         self.exclusive_arch = _DOTNET_EXCLUSIVE_ARCH
 
         self._min_release_counter = {"8.0": 20, "6.0": 32}[str(self.version)]
+        self._custom_test_env = "dotnet"
 
     def _fetch_ordinary_package(self, pkg: str | Package) -> list[RpmPackage]:
         """Fetches the package `pkg` from the microsoft .Net repository and

--- a/src/staging/release_bot.py
+++ b/src/staging/release_bot.py
@@ -1,0 +1,231 @@
+from dataclasses import dataclass
+from dataclasses import field
+from enum import Enum
+from enum import unique
+from typing import Any
+
+from ruamel.yaml.scalarstring import SingleQuotedScalarString
+
+from bci_build.package import ALL_CONTAINER_IMAGE_NAMES
+from bci_build.package import ApplicationStackContainer
+from bci_build.package import Arch
+from bci_build.package import BaseContainerImage
+from bci_build.package import DevelopmentContainer
+from bci_build.package import OsContainer
+from bci_build.package import OsVersion
+from dotnet.updater import DOTNET_IMAGES
+
+_DEFAULTS = {
+    "defaults": {
+        "arch": ["aarch64", "x86_64", "s390x", "ppc64le"],
+        "settings": {
+            "RETRY": 1,
+            "BCI_TEST_ENVS": SingleQuotedScalarString("all,metadata"),
+        },
+    }
+}
+
+
+@dataclass(frozen=True)
+class TestSettings:
+    BCI_TEST_ENVS: str = ""
+    BCI_IMAGE_MARKER: str = ""
+    BCI_IMAGE_NAME: str = ""
+    CONTAINER_IMAGE_TO_TEST: str = ""
+
+
+@dataclass(frozen=True)
+class TestPackage:
+    project: str = ""
+    repo: str = ""
+    package: str = ""
+
+
+@dataclass(frozen=True)
+class ReleasePackage(TestPackage):
+    prefix: str = ""
+
+
+def get_groupid(ctr: BaseContainerImage) -> int:
+    if isinstance(ctr, ApplicationStackContainer):
+        return 445
+    if isinstance(ctr, DevelopmentContainer):
+        return 444
+
+    return {
+        OsVersion.SP3: 442,
+        OsVersion.SP4: 443,
+        OsVersion.SP5: 475,
+        OsVersion.SP6: 538,
+    }[ctr.os_version]
+
+
+@dataclass(frozen=True)
+class ContainerTest:
+    version: str
+    flavor: str = "BCI-Updates"
+    build: str = "%build_%sourcepackage"
+    groupid: int = 0
+
+    arch: list[Arch] | None = None
+
+    settings: TestSettings = field(default_factory=TestSettings)
+    source: TestPackage = field(default_factory=TestPackage)
+    testing: TestPackage = field(default_factory=TestPackage)
+    release: ReleasePackage = field(default_factory=ReleasePackage)
+
+    @staticmethod
+    def _recursive_to_str(d: dict[str, Any]) -> dict[str, Any]:
+        for k, v in d.items():
+            if isinstance(v, str):
+                d[k] = SingleQuotedScalarString(value=v)
+            elif isinstance(v, dict):
+                d[k] = ContainerTest._recursive_to_str(v)
+
+        return d
+
+    def to_dict(self) -> dict[str, Any]:
+        res = {}
+        for k, v in self.__dict__.items():
+            if not v:
+                continue
+
+            if k == "arch":
+                assert self.arch is not None
+                # omit exclusive arch when it's all architectures
+                if len(self.arch) != 4:
+                    res[k] = [str(arch) for arch in self.arch]
+
+            else:
+                if hasattr(v, "__dict__"):
+                    res[k] = v.__dict__
+                else:
+                    res[k] = v
+        return ContainerTest._recursive_to_str(res)
+
+
+@unique
+class ContainerFamily(Enum):
+    APPLICATION = "app"
+    LANGUAGE = "lang"
+
+
+def generate_containers_test(family: OsVersion | ContainerFamily) -> dict[str, Any]:
+    res = {}
+
+    for ctr in list(ALL_CONTAINER_IMAGE_NAMES.values()) + DOTNET_IMAGES:
+        if not ctr.os_version.is_sle15:
+            continue
+
+        if isinstance(family, OsVersion) and (
+            family != ctr.os_version or not isinstance(ctr, OsContainer)
+        ):
+            continue
+
+        if isinstance(family, ContainerFamily):
+            if family == ContainerFamily.APPLICATION and not isinstance(
+                ctr, ApplicationStackContainer
+            ):
+                continue
+
+            # skip everything that is not a devcontainer but that is an
+            # appcontainer (appcontainers are subclases of devcontainers)
+            if family == ContainerFamily.LANGUAGE:
+                if isinstance(ctr, ApplicationStackContainer):
+                    continue
+                if not isinstance(ctr, DevelopmentContainer):
+                    continue
+
+        SP = ctr.os_version.pretty_print
+        name = f"SLE15-{SP}-{ctr.uid}"
+
+        source = TestPackage(
+            project=(cr := f"SUSE:SLE-15-{SP}:Update:CR"),
+            package=ctr.package_name,
+            repo=ctr.build_recipe_type.repository_name,
+        )
+        testing = TestPackage(
+            project=f"{cr}:ToTest", package=ctr.package_name, repo="images"
+        )
+        release = ReleasePackage(
+            project=f"SUSE:Containers:SLE-SERVER:15-{SP}",
+            package="",
+            prefix=ctr.package_name,
+            repo="containers",
+        )
+
+        registry_path = f"registry.suse.de/suse/sle-15-{SP.lower()}/update/cr/totest/images/{ctr.build_tags[0]}"
+        if registry_path.endswith("%OS_VERSION_ID_SP%"):
+            registry_path = registry_path.replace(
+                "%OS_VERSION_ID_SP%",
+                OsContainer.version_to_container_os_version(ctr.os_version),
+            )
+        test_envs = TestSettings(
+            BCI_TEST_ENVS=f"all,metadata,{ctr.test_environment}",
+            BCI_IMAGE_MARKER=ctr.test_marker,
+            BCI_IMAGE_NAME=ctr.test_marker,
+            CONTAINER_IMAGE_TO_TEST=registry_path,
+        )
+
+        test = ContainerTest(
+            version=f"15-{SP}",
+            groupid=get_groupid(ctr),
+            source=source,
+            testing=testing,
+            release=release,
+            settings=test_envs,
+            arch=ctr.exclusive_arch,
+        )
+
+        res[name] = test.to_dict()
+
+    return {**_DEFAULTS, "projects": res}
+
+
+def dump_data() -> None:
+    import argparse
+    import os.path
+
+    from ruamel.yaml import YAML
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--ctr-family",
+        "-f",
+        nargs=1,
+        required=True,
+        choices=[
+            str(v.value)
+            for v in (
+                ContainerFamily.APPLICATION,
+                ContainerFamily.LANGUAGE,
+                OsVersion.SP3,
+                OsVersion.SP4,
+                OsVersion.SP5,
+                OsVersion.SP6,
+            )
+        ],
+    )
+    parser.add_argument(
+        "--destination",
+        "-d",
+        nargs=1,
+        required=True,
+        type=str,
+        help="File to which the yaml will be written",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        family = OsVersion.parse(args.ctr_family[0])
+    except ValueError:
+        family = ContainerFamily(args.ctr_family[0])
+
+    yaml = YAML(typ="rt", output=open(os.path.expanduser(args.destination[0]), "w"))
+    yaml.preserve_quotes = False
+    yaml.map_indent = 2
+    yaml.sequence_indent = 2
+
+    with yaml:
+        yaml.dump(generate_containers_test(family))


### PR DESCRIPTION
This PR adds some preliminary capability for the dockerfile generator to create the container-release-bot's YAML config file.

I haven't tested this thoroughly, so far I only ran it for the language containers via:
```ShellSession
$ poetry run dump-crb-yaml -f=lang -d=path/to/gitlab.suse.de/qac/container-release-bot/containers/lang.yaml
```

The produced diff is pretty big, but it's mostly moving yaml chunks around (although that is arguably hard to verify). There's still some bugs, e.g. the rust & go entries use the version numbers and not the stability tags.