### PR TITLE
Specify java 21 as the preferred java to pull in for the Kiwi container

### DIFF
--- a/src/bci_build/package/kiwi.py
+++ b/src/bci_build/package/kiwi.py
@@ -33,6 +33,7 @@ KIWI_CONTAINERS = [
             "gcc",
             "glibc-devel",
             "iproute2",
+            "java-21-openjdk-headless",
             "jing",
             "kiwi-systemdeps-filesystems",
             "kpartx",


### PR DESCRIPTION
Otherwise java 8 is pulled via dependency resolution, which is only in legacy module