### PR TITLE
Restore uid for the base container image

### DIFF
--- a/src/bci_build/package/base.py
+++ b/src/bci_build/package/base.py
@@ -107,6 +107,10 @@ class Sles15Image(OsContainer):
         tags += super().build_tags
         return tags
 
+    @property
+    def uid(self) -> str:
+        return "sles15"
+
 
 def _get_base_kwargs(os_version: OsVersion) -> dict:
     package_name: str = "base-image"


### PR DESCRIPTION
Otherwise we have unresolvable errors like:
  have choice for container:suse/sle15:15.6: container:base-image container:sles15-image