### PR TITLE
Add OCI image ref annotation to the BCI containers

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -998,10 +998,19 @@ exit 0
 
     @property
     @abc.abstractmethod
+    def image_ref_name(self) -> str:
+        """The immutable reference for this target under which this image can be pulled. It is used
+        to set the ``org.opencontainers.image.ref.name`` OCI annotation and defaults to
+        ``{self.build_tags[0]}``.
+        """
+        pass
+
+    @property
+    @abc.abstractmethod
     def reference(self) -> str:
         """The primary URL via which this image can be pulled. It is used to set the
         ``org.opensuse.reference`` label and defaults to
-        ``{self.registry}/{self.build_tags[0]}``.
+        ``{self.registry}/{self.image_ref_name}``.
 
         """
         pass
@@ -1394,10 +1403,13 @@ class DevelopmentContainer(BaseContainerImage):
         return tags
 
     @property
+    def image_ref_name(self) -> str:
+        return f"{self.version_label}-{self._release_suffix}"
+
+    @property
     def reference(self) -> str:
         return (
-            f"{self.registry}/{self._registry_prefix}/{self.name}"
-            + f":{self.version_label}-{self._release_suffix}"
+            f"{self.registry}/{self._registry_prefix}/{self.name}:{self.image_ref_name}"
         )
 
     @property
@@ -1491,8 +1503,12 @@ class OsContainer(BaseContainerImage):
         return tags
 
     @property
+    def image_ref_name(self) -> str:
+        return self.version_label
+
+    @property
     def reference(self) -> str:
-        return f"{self.registry}/{self._registry_prefix}/bci-{self.name}:{self.version_label}"
+        return f"{self.registry}/{self._registry_prefix}/bci-{self.name}:{self.image_ref_name}"
 
     @property
     def pretty_reference(self) -> str:

--- a/src/bci_build/templates.py
+++ b/src/bci_build/templates.py
@@ -50,6 +50,7 @@ LABEL org.opencontainers.image.url="{{ image.url }}"
 LABEL org.opencontainers.image.created="%BUILDTIME%"
 LABEL org.opencontainers.image.vendor="{{ image.vendor }}"
 LABEL org.opencontainers.image.source="%SOURCEURL%"
+LABEL org.opencontainers.image.ref.name="{{ image.image_ref_name }}"
 LABEL org.opensuse.reference="{{ image.reference }}"
 LABEL org.openbuildservice.disturl="%DISTURL%"
 {%- if image.os_version.is_tumbleweed %}
@@ -125,6 +126,7 @@ KIWI_TEMPLATE = jinja2.Template(
             <label name="org.opencontainers.image.vendor" value="{{ image.vendor }}"/>
             <label name="org.opencontainers.image.source" value="%SOURCEURL%"/>
             <label name="org.opencontainers.image.url" value="{{ image.url }}"/>
+            <label name="org.opencontainers.image.ref.name" value="{{ image.image_ref_name }}"/>
             <label name="org.opensuse.reference" value="{{ image.reference }}"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
 {%- if not image.os_version.is_tumbleweed %}

--- a/tests/test_build_recipe.py
+++ b/tests/test_build_recipe.py
@@ -37,6 +37,7 @@ LABEL org.opencontainers.image.url="https://www.suse.com/products/base-container
 LABEL org.opencontainers.image.created="%BUILDTIME%"
 LABEL org.opencontainers.image.vendor="SUSE LLC"
 LABEL org.opencontainers.image.source="%SOURCEURL%"
+LABEL org.opencontainers.image.ref.name="27-%RELEASE%"
 LABEL org.opensuse.reference="registry.suse.com/bci/test:27-%RELEASE%"
 LABEL org.openbuildservice.disturl="%DISTURL%"
 LABEL com.suse.supportlevel="techpreview"
@@ -79,6 +80,7 @@ RUN emacs -Q --batch test.el
             <label name="org.opencontainers.image.vendor" value="SUSE LLC"/>
             <label name="org.opencontainers.image.source" value="%SOURCEURL%"/>
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/base-container-images/"/>
+            <label name="org.opencontainers.image.ref.name" value="27-%RELEASE%"/>
             <label name="org.opensuse.reference" value="registry.suse.com/bci/test:27-%RELEASE%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
             <label name="com.suse.supportlevel" value="techpreview"/>
@@ -140,6 +142,7 @@ LABEL org.opencontainers.image.url="https://www.suse.com/products/base-container
 LABEL org.opencontainers.image.created="%BUILDTIME%"
 LABEL org.opencontainers.image.vendor="SUSE LLC"
 LABEL org.opencontainers.image.source="%SOURCEURL%"
+LABEL org.opencontainers.image.ref.name="%%emacs_ver%%-1.%RELEASE%"
 LABEL org.opensuse.reference="registry.suse.com/bci/test:%%emacs_ver%%-1.%RELEASE%"
 LABEL org.openbuildservice.disturl="%DISTURL%"
 LABEL com.suse.supportlevel="techpreview"
@@ -179,6 +182,7 @@ RUN zypper -n in --no-recommends gcc emacs; zypper -n clean; ##LOGCLEAN##
             <label name="org.opencontainers.image.vendor" value="SUSE LLC"/>
             <label name="org.opencontainers.image.source" value="%SOURCEURL%"/>
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/base-container-images/"/>
+            <label name="org.opencontainers.image.ref.name" value="%%emacs_ver%%-1.%RELEASE%"/>
             <label name="org.opensuse.reference" value="registry.suse.com/bci/test:%%emacs_ver%%-1.%RELEASE%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
             <label name="com.suse.supportlevel" value="techpreview"/>
@@ -234,6 +238,7 @@ LABEL org.opencontainers.image.url="https://www.suse.com/products/base-container
 LABEL org.opencontainers.image.created="%BUILDTIME%"
 LABEL org.opencontainers.image.vendor="SUSE LLC"
 LABEL org.opencontainers.image.source="%SOURCEURL%"
+LABEL org.opencontainers.image.ref.name="29-%RELEASE%"
 LABEL org.opensuse.reference="registry.suse.com/bci/test:29-%RELEASE%"
 LABEL org.openbuildservice.disturl="%DISTURL%"
 LABEL com.suse.supportlevel="techpreview"
@@ -274,6 +279,7 @@ USER emacs""",
             <label name="org.opencontainers.image.vendor" value="SUSE LLC"/>
             <label name="org.opencontainers.image.source" value="%SOURCEURL%"/>
             <label name="org.opencontainers.image.url" value="https://www.suse.com/products/base-container-images/"/>
+            <label name="org.opencontainers.image.ref.name" value="29-%RELEASE%"/>
             <label name="org.opensuse.reference" value="registry.suse.com/bci/test:29-%RELEASE%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
             <label name="com.suse.supportlevel" value="techpreview"/>
@@ -336,6 +342,7 @@ LABEL org.opencontainers.image.url="https://www.opensuse.org"
 LABEL org.opencontainers.image.created="%BUILDTIME%"
 LABEL org.opencontainers.image.vendor="openSUSE Project"
 LABEL org.opencontainers.image.source="%SOURCEURL%"
+LABEL org.opencontainers.image.ref.name="28.2-%RELEASE%"
 LABEL org.opensuse.reference="registry.opensuse.org/opensuse/bci/test:28.2-%RELEASE%"
 LABEL org.openbuildservice.disturl="%DISTURL%"
 LABEL org.opensuse.lifecycle-url="https://en.opensuse.org/Lifetime#openSUSE_BCI"
@@ -384,6 +391,7 @@ VOLUME /bin/ /usr/bin/""",
             <label name="org.opencontainers.image.vendor" value="openSUSE Project"/>
             <label name="org.opencontainers.image.source" value="%SOURCEURL%"/>
             <label name="org.opencontainers.image.url" value="https://www.opensuse.org"/>
+            <label name="org.opencontainers.image.ref.name" value="28.2-%RELEASE%"/>
             <label name="org.opensuse.reference" value="registry.opensuse.org/opensuse/bci/test:28.2-%RELEASE%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
             <label name="org.opensuse.release-stage" value="released"/>
@@ -499,6 +507,7 @@ def test_build_recipe_templates(
             <label name="org.opencontainers.image.vendor" value="openSUSE Project"/>
             <label name="org.opencontainers.image.source" value="%SOURCEURL%"/>
             <label name="org.opencontainers.image.url" value="https://www.opensuse.org"/>
+            <label name="org.opencontainers.image.ref.name" value="%OS_VERSION_ID_SP%.%RELEASE%"/>
             <label name="org.opensuse.reference" value="registry.opensuse.org/opensuse/bci/bci-test:%OS_VERSION_ID_SP%.%RELEASE%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
             <label name="org.opensuse.release-stage" value="released"/>


### PR DESCRIPTION
This is optional but required by the Rancher Application Collection