### PR TITLE
Allow to customize the oci image version label for AppCollection

### DIFF
--- a/src/bci_build/package/apache-tomcat/README.md.j2
+++ b/src/bci_build/package/apache-tomcat/README.md.j2
@@ -1,4 +1,4 @@
-# Tomcat {{ image.version }} container image
+# Tomcat {{ image.env['TOMCAT_MAJOR'] }} container image
 {% include 'badges.j2' %}
 
 ## Description

--- a/src/bci_build/package/apache_tomcat.py
+++ b/src/bci_build/package/apache_tomcat.py
@@ -59,7 +59,8 @@ TOMCAT_CONTAINERS = [
             and jre_version == 22
             and os_version.is_tumbleweed
         ),
-        version=f"{tomcat_major}-jre{jre_version}",
+        version="%%tomcat_version%%",
+        tag_version=f"{tomcat_major}-jre{jre_version}",
         supported_until=_get_sac_supported_until(
             os_version=os_version, tomcat_major=tomcat_major, jre_major=jre_version
         ),
@@ -86,7 +87,7 @@ TOMCAT_CONTAINERS = [
             ),
         ],
         cmd=[
-            f"/usr/{'libexec' if os_version in( OsVersion.TUMBLEWEED, OsVersion.SLE16_0) else 'lib'}/tomcat/server",
+            f"/usr/{'libexec' if os_version in (OsVersion.TUMBLEWEED, OsVersion.SLE16_0) else 'lib'}/tomcat/server",
             "start",
         ],
         exposes_tcp=[8080],

--- a/src/bci_build/package/base.py
+++ b/src/bci_build/package/base.py
@@ -102,7 +102,7 @@ class Sles15Image(OsContainer):
         tags: list[str] = []
         if self.os_version.is_sle15:
             tags.extend(
-                ("suse/sle15:%OS_VERSION_ID_SP%", f"suse/sle15:{self.version_label}")
+                ("suse/sle15:%OS_VERSION_ID_SP%", f"suse/sle15:{self.image_ref_name}")
             )
         tags += super().build_tags
         return tags

--- a/src/bci_build/templates.py
+++ b/src/bci_build/templates.py
@@ -45,7 +45,7 @@ DOCKERFILE_TEMPLATE = jinja2.Template(
 LABEL org.opencontainers.image.authors="{{ image.maintainer }}"
 LABEL org.opencontainers.image.title="{{ image.title }}"
 LABEL org.opencontainers.image.description="{{ image.description }}"
-LABEL org.opencontainers.image.version="{{ image.version_label }}"
+LABEL org.opencontainers.image.version="{{ image.oci_version }}"
 LABEL org.opencontainers.image.url="{{ image.url }}"
 LABEL org.opencontainers.image.created="%BUILDTIME%"
 LABEL org.opencontainers.image.vendor="{{ image.vendor }}"
@@ -121,7 +121,7 @@ KIWI_TEMPLATE = jinja2.Template(
             <label name="org.opencontainers.image.authors" value="{{ image.maintainer }}"/>
             <label name="org.opencontainers.image.title" value="{{ image.title }}"/>
             <label name="org.opencontainers.image.description" value="{{ image.description }}"/>
-            <label name="org.opencontainers.image.version" value="{{ image.version_label }}"/>
+            <label name="org.opencontainers.image.version" value="{{ image.oci_version }}"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
             <label name="org.opencontainers.image.vendor" value="{{ image.vendor }}"/>
             <label name="org.opencontainers.image.source" value="%SOURCEURL%"/>


### PR DESCRIPTION
OCI requires the full application verison in the oci.version label,
however when we have variants we need to suffix the primary tag
version with a variant suffix. split version_label into two
properties, tag_version and oci_version to refer to each.

tag_version then gains support for variants by adding an optional
verion_variant attribute to the container definion.