### PR TITLE
Adding Kiwi stackbuild plugin for container image based builds

### DIFF
--- a/src/bci_build/package/kiwi.py
+++ b/src/bci_build/package/kiwi.py
@@ -43,6 +43,7 @@ KIWI_CONTAINERS = [
             "netcat-openbsd",
             "python3-devel",
             "python3-kiwi",
+            "python3-kiwi_stackbuild_plugin",
             "python3-pip",
             "tack",
             "timezone",


### PR DESCRIPTION
In this PR I'm seeking the addition of the python3-kiwi_stackbuild_plugin, but I'm not sure if it's available in the standard repositories.