### PR TITLE
Avoid randomly ordered package names in the commit message

### DIFF
--- a/src/staging/bot.py
+++ b/src/staging/bot.py
@@ -1400,7 +1400,7 @@ updates:
             for commit in commits:
                 package_names.extend(self._get_changed_packages_by_commit(commit))
 
-            package_names = list(set(package_names))
+            package_names = sorted(set(package_names))
 
         if not package_names:
             raise ValueError(


### PR DESCRIPTION
This is slightly annoying to review otherwise.