### PR TITLE
MariaDB gosu - use exec and quote user

### DIFF
--- a/src/bci_build/package/mariadb.py
+++ b/src/bci_build/package/mariadb.py
@@ -21,12 +21,12 @@ _MARIADB_GOSU = b"""#!/bin/bash
 u=$1
 shift
 
-if ! id -u $u > /dev/null 2>&1; then
+if ! id -u "$u" > /dev/null 2>&1; then
     echo "Invalid user: $u"
     exit 1
 fi
 
-setpriv --reuid=$u --regid=$u --clear-groups -- /bin/bash "$@"
+exec setpriv --reuid="$u" --regid="$u" --clear-groups -- "$@"
 """
 
 MARIADB_CONTAINERS = []


### PR DESCRIPTION
Without exec, the mariadbd doesn't end up with PID 1 and this results in errors managing the container.

bash was also unneeded.

Closes https://bugzilla.opensuse.org/show_bug.cgi?id=1213154