### PR TITLE
Order choices for package by container name

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -1615,7 +1615,7 @@ ALL_CONTAINER_IMAGE_NAMES: dict[str, BaseContainerImage] = {
 
 SORTED_CONTAINER_IMAGE_NAMES = sorted(
     ALL_CONTAINER_IMAGE_NAMES,
-    key=lambda bci: str(ALL_CONTAINER_IMAGE_NAMES[bci].os_version),
+    key=lambda bci: f"{ALL_CONTAINER_IMAGE_NAMES[bci].os_version}-{ALL_CONTAINER_IMAGE_NAMES[bci].name}",
 )
 
 


### PR DESCRIPTION
Just sorting on version leaves the rest unpredictably sorted which makes it really hard to find the right name.