### PR TITLE
Fix fetching of the mariadb scripts

### DIFF
--- a/src/bci_build/package/mariadb/10.11/healthcheck.sh
+++ b/src/bci_build/package/mariadb/10.11/healthcheck.sh
@@ -10,8 +10,8 @@
 # the --replication option. This allows a different set of replication checks
 # on different connections.
 #
-# --su{=|-mariadb} is option to run the healthcheck as a different unix user.
-# Useful if mariadb@localhost user exists with unix socket authentication
+# --su{=|-mysql} is option to run the healthcheck as a different unix user.
+# Useful if mysql@localhost user exists with unix socket authentication
 # Using this option disregards previous options set, so should usually be the
 # first option.
 #
@@ -32,7 +32,7 @@
 # different from elsewhere.
 #
 # Note * though denied error message will result in error log without
-#      any permissions.
+#      any permissions. USAGE recommend to avoid this.
 
 set -eo pipefail
 
@@ -42,6 +42,7 @@ _process_sql()
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}} \
 		${def['group_suffix']:+--defaults-group-suffix=${def['group_suffix']}} \
+		--protocol socket \
 		-B "$@"
 }
 
@@ -55,6 +56,16 @@ _process_sql()
 # isn't tested.
 connect()
 {
+	local s
+	# short cut mechanism, to work with --require-secure-transport
+	s=$(_process_sql --skip-column-names -e 'select @@skip_networking')
+	case "$s" in
+		0|1)
+			connect_s=$s
+			return "$s";
+			;;
+	esac
+	# falling back to this if there wasn't a connection answer.
 	set +e +o pipefail
 	# (on second extra_file)
 	# shellcheck disable=SC2086
@@ -68,9 +79,11 @@ connect()
 	set -eo pipefail
 	if (( "$ret" == 0 )); then
 		# grep Matched "Can't connect" so we fail
-		return 1
+		connect_s=1
+	else
+		connect_s=0
 	fi
-	return 0
+	return $connect_s
 }
 
 # INNODB_INITIALIZED
@@ -225,6 +238,7 @@ fi
 declare -A repl
 declare -A def
 nodefaults=
+connect_s=
 datadir=/var/lib/mysql
 if [ -f $datadir/.my-healthcheck.cnf ]; then
 	def['extra_file']=$datadir/.my-healthcheck.cnf
@@ -351,3 +365,9 @@ while [ $# -gt 0 ]; do
 	fi
 	shift
 done
+if [ -z "$connect_s" ]; then
+	# we didn't do a connnect test, so the current success status is suspicious
+	# return what connect thinks.
+	connect
+	exit $?
+fi

--- a/src/bci_build/package/mariadb/10.6/entrypoint.sh
+++ b/src/bci_build/package/mariadb/10.6/entrypoint.sh
@@ -204,9 +204,11 @@ docker_create_db_directories() {
 
 	if [ "$user" = "0" ]; then
 		# this will cause less disk access than `chown -R`
-		find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql -exec chown mysql: '{}' \;
+		if [ "${SOCKET:0:1}" != '@' ]; then # not abstract sockets
+			find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		fi
 
 	fi
 }
@@ -345,7 +347,7 @@ create_healthcheck_users() {
 	local maskPreserve
 	maskPreserve=$(umask -p)
 	umask 0077
-	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\n" > "$DATADIR"/.my-healthcheck.cnf
 	$maskPreserve
 }
 
@@ -518,7 +520,7 @@ docker_mariadb_init()
 			rm -rf "$DATADIR"/.init "$DATADIR"/.restore
 			if [ "$(id -u)" = "0" ]; then
 				# this will cause less disk access than `chown -R`
-				find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+				find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 			fi
 		done
 		if _check_if_upgrade_is_needed; then

--- a/src/bci_build/package/mariadb/10.6/healthcheck.sh
+++ b/src/bci_build/package/mariadb/10.6/healthcheck.sh
@@ -10,8 +10,8 @@
 # the --replication option. This allows a different set of replication checks
 # on different connections.
 #
-# --su{=|-mariadb} is option to run the healthcheck as a different unix user.
-# Useful if mariadb@localhost user exists with unix socket authentication
+# --su{=|-mysql} is option to run the healthcheck as a different unix user.
+# Useful if mysql@localhost user exists with unix socket authentication
 # Using this option disregards previous options set, so should usually be the
 # first option.
 #
@@ -32,7 +32,7 @@
 # different from elsewhere.
 #
 # Note * though denied error message will result in error log without
-#      any permissions.
+#      any permissions. USAGE recommend to avoid this.
 
 set -eo pipefail
 
@@ -42,6 +42,7 @@ _process_sql()
 		${def['file']:+--defaults-file=${def['file']}} \
 		${def['extra_file']:+--defaults-extra-file=${def['extra_file']}} \
 		${def['group_suffix']:+--defaults-group-suffix=${def['group_suffix']}} \
+		--protocol socket \
 		-B "$@"
 }
 
@@ -55,6 +56,16 @@ _process_sql()
 # isn't tested.
 connect()
 {
+	local s
+	# short cut mechanism, to work with --require-secure-transport
+	s=$(_process_sql --skip-column-names -e 'select @@skip_networking')
+	case "$s" in
+		0|1)
+			connect_s=$s
+			return "$s";
+			;;
+	esac
+	# falling back to this if there wasn't a connection answer.
 	set +e +o pipefail
 	# (on second extra_file)
 	# shellcheck disable=SC2086
@@ -68,9 +79,11 @@ connect()
 	set -eo pipefail
 	if (( "$ret" == 0 )); then
 		# grep Matched "Can't connect" so we fail
-		return 1
+		connect_s=1
+	else
+		connect_s=0
 	fi
-	return 0
+	return $connect_s
 }
 
 # INNODB_INITIALIZED
@@ -225,6 +238,7 @@ fi
 declare -A repl
 declare -A def
 nodefaults=
+connect_s=
 datadir=/var/lib/mysql
 if [ -f $datadir/.my-healthcheck.cnf ]; then
 	def['extra_file']=$datadir/.my-healthcheck.cnf
@@ -351,3 +365,9 @@ while [ $# -gt 0 ]; do
 	fi
 	shift
 done
+if [ -z "$connect_s" ]; then
+	# we didn't do a connnect test, so the current success status is suspicious
+	# return what connect thinks.
+	connect
+	exit $?
+fi

--- a/src/bci_build/package/mariadb/11.4/entrypoint.sh
+++ b/src/bci_build/package/mariadb/11.4/entrypoint.sh
@@ -206,9 +206,11 @@ docker_create_db_directories() {
 
 	if [ "$user" = "0" ]; then
 		# this will cause less disk access than `chown -R`
-		find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+		find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 		# See https://github.com/MariaDB/mariadb-docker/issues/363
-		find "${SOCKET%/*}" -maxdepth 0 \! -user mysql -exec chown mysql: '{}' \;
+		if [ "${SOCKET:0:1}" != '@' ]; then # not abstract sockets
+			find "${SOCKET%/*}" -maxdepth 0 \! -user mysql \( -exec chown mysql: '{}' \; -o -true \)
+		fi
 
 		# memory.pressure
 		local cgroup; cgroup=$(</proc/self/cgroup)
@@ -355,7 +357,7 @@ create_healthcheck_users() {
 	local maskPreserve
 	maskPreserve=$(umask -p)
 	umask 0077
-	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\nprotocol=tcp\\n" > "$DATADIR"/.my-healthcheck.cnf
+	echo -e "[mariadb-client]\\nport=$PORT\\nsocket=$SOCKET\\nuser=healthcheck\\npassword=$healthCheckConnectPass\\n" > "$DATADIR"/.my-healthcheck.cnf
 	$maskPreserve
 }
 
@@ -528,7 +530,7 @@ docker_mariadb_init()
 			rm -rf "$DATADIR"/.init "$DATADIR"/.restore
 			if [ "$(id -u)" = "0" ]; then
 				# this will cause less disk access than `chown -R`
-				find "$DATADIR" \! -user mysql -exec chown mysql: '{}' +
+				find "$DATADIR" \! -user mysql \( -exec chown mysql: '{}' + -o -true \)
 			fi
 		done
 		if _check_if_upgrade_is_needed; then

--- a/update-files.sh
+++ b/update-files.sh
@@ -14,7 +14,7 @@ curl -sf -o src/bci_build/package/grafana/run.sh https://raw.githubusercontent.c
 
 command -v jq > /dev/null || { echo "we need jq installed for update to work"; exit 1; }
 rm -f src/bci_build/package/mariadb/*/entrypoint.sh src/bci_build/package/mariadb/*/healthcheck.sh
-for v in $(jq -r '.mariadb|.[]' src/bci_build/package/package_versions.json | cut -d. -f1-2 | sort -u); do
+for v in $(jq -r '.mariadb | del(.version_format) | .[]' src/bci_build/package/package_versions.json | cut -d. -f1-2 | sort -u); do
     mkdir -p "src/bci_build/package/mariadb/$v"
     curl -sf -o "src/bci_build/package/mariadb/$v/entrypoint.sh" "https://raw.githubusercontent.com/MariaDB/mariadb-docker/master/$v/docker-entrypoint.sh"
     curl -sf -o "src/bci_build/package/mariadb/$v/healthcheck.sh" "https://raw.githubusercontent.com/MariaDB/mariadb-docker/master/$v/healthcheck.sh"


### PR DESCRIPTION
3264da304a5ed7fe3ff03936277d0e02d00d7b04 broke update-files becaues it now tried to fetch the files called "minor" from GitHub which do not exist. This would have been prevented by having versions in a separate object tree.