### PR TITLE
Add marker that excludes Liberty and other non-SUSE host kernels

### DIFF
--- a/src/bci_build/package/kiwi.py
+++ b/src/bci_build/package/kiwi.py
@@ -50,6 +50,9 @@ KIWI_CONTAINERS = [
         ],
         custom_end=f"{generate_package_version_check('python3-kiwi', kiwi_minor, ParseVersion.MINOR)}",
         build_recipe_type=BuildType.DOCKER,
+        extra_labels={
+            "usage": "This container requires an openSUSE/SUSE host kernel for full functionality.",
+        },
     )
     for os_version in ALL_NONBASE_OS_VERSIONS
 ]


### PR DESCRIPTION
the primary usecase for the kiwi container is to build custom SLE Micro installation images, which means btrfs support is a must.