### PR TITLE
[postfix] update entrypoint.sh to remove syslogd dependency

### DIFF
--- a/src/bci_build/package/postfix.py
+++ b/src/bci_build/package/postfix.py
@@ -69,11 +69,11 @@ POSTFIX_CONTAINERS = [
                     "spamass-milter",
                 )
                 if os_version == OsVersion.TUMBLEWEED
-                else ("rsyslog", "gawk")
+                else ()
             )
         ],
         entrypoint=["/entrypoint/entrypoint.sh"],
-        cmd=["postfix", "start"],
+        cmd=["postfix", "start-fg"],
         extra_files=_POSTFIX_FILES,
         support_level=SupportLevel.TECHPREVIEW,
         exposes_tcp=[25, 465, 587],

--- a/src/bci_build/package/postfix/entrypoint/entrypoint.sh
+++ b/src/bci_build/package/postfix/entrypoint/entrypoint.sh
@@ -166,7 +166,6 @@ setup_submission() {
 	echo "Enable submission port"
 
 	echo "submission inet n       -       n       -       -       smtpd" >> /etc/postfix/master.cf
-	echo " -o syslog_name=postfix/submission" >> /etc/postfix/master.cf
 
 	if [ "${SMTPD_USE_TLS}" -eq "1" ]; then
 	    echo " -o smtpd_tls_security_level=encrypt" >> /etc/postfix/master.cf
@@ -180,7 +179,6 @@ setup_submission() {
 	    echo "Enable submissions port"
 
 	    echo "smtps inet n       -       n       -       -       smtpd" >> /etc/postfix/master.cf
-	    echo " -o syslog_name=postfix/smtps" >> /etc/postfix/master.cf
 	    echo " -o smtpd_tls_wrappermode=yes" >> /etc/postfix/master.cf
 	    echo " -o smtpd_sasl_auth_enable=no" >> /etc/postfix/master.cf
 	else
@@ -194,7 +192,9 @@ setup_submission() {
 	SMTPD_TLS_CRT=${SMTPD_TLS_CRT:-"/etc/postfix/ssl/certs/tls.crt"}
 	SMTPD_TLS_KEY=${SMTPD_TLS_KEY:-"/etc/postfix/ssl/certs/tls.key"}
 
+	# smtpd_use_tls is deprecated and only for compatibility
 	set_config_value "smtpd_use_tls" "yes"
+	set_config_value "smtpd_tls_security_level" "may"
 	set_config_value "smtpd_tls_CApath" "/etc/ssl/certs"
 	set_config_value "smtpd_tls_cert_file" "${SMTPD_TLS_CRT}"
 	set_config_value "smtpd_tls_key_file" "${SMTPD_TLS_KEY}"
@@ -350,6 +350,10 @@ configure_postfix() {
 	update_db "${i}"
     done
     set_config_value "smtpd_sender_restrictions" "lmdb:/etc/postfix/access"
+
+    # Log to stdout
+    set_config_value "maillog_file" "/dev/stdout"
+
     # Generate and update maps
     update_db access relay relay_recipients
 
@@ -397,25 +401,11 @@ stop_postfix() {
     ) > /dev/null 2>&1 &
 
     postfix stop
-    terminate /usr/sbin/syslogd
 }
 
 stop_daemons() {
     stop_postfix "$@"
     stop_spamassassin
-}
-
-start_daemons() {
-    # Don't start syslogd in background while starting it in the background...
-    # Logging to stdout does not work else.
-    /usr/sbin/syslogd -n -S -O - &
-    if [ -n "${SPAMASSASSIN_HOST}" ]; then
-	mkdir /run/spamass-milter
-	chown sa-milter:postfix /run/spamass-milter
-	chmod 751 /run/spamass-milter
-	su sa-milter -s /bin/sh -c "/usr/sbin/spamass-milter -p /run/spamass-milter/socket -g postfix -f -- -d ${SPAMASSASSIN_HOST}"
-    fi
-    "$@"
 }
 
 #
@@ -424,7 +414,7 @@ start_daemons() {
 
 # if command starts with an option, prepend postfix
 if [ "${1:0:1}" = '-' ]; then
-        set -- postfix start "$@"
+        set -- postfix start-fg "$@"
 fi
 
 init_trap
@@ -441,9 +431,11 @@ setup_spamassassin
 rm -f /var/spool/postfix/pid/master.pid
 
 if [ "$1" = 'postfix' ]; then
-    start_daemons "$@"
-    echo "postfix running and ready"
-    sleep infinity & wait $!
-else
-    exec "$@"
+    if [ -n "${SPAMASSASSIN_HOST}" ]; then
+	mkdir /run/spamass-milter
+	chown sa-milter:postfix /run/spamass-milter
+	chmod 751 /run/spamass-milter
+	su sa-milter -s /bin/sh -c "/usr/sbin/spamass-milter -p /run/spamass-milter/socket -g postfix -f -- -d ${SPAMASSASSIN_HOST}"
+    fi
 fi
+exec "$@"

--- a/src/bci_build/package/postfix/entrypoint/entrypoint.sles.sh
+++ b/src/bci_build/package/postfix/entrypoint/entrypoint.sles.sh
@@ -166,7 +166,6 @@ setup_submission() {
 	echo "Enable submission port"
 
 	echo "submission inet n       -       n       -       -       smtpd" >> /etc/postfix/master.cf
-	echo " -o syslog_name=postfix/submission" >> /etc/postfix/master.cf
 
 	if [ "${SMTPD_USE_TLS}" -eq "1" ]; then
 	    echo " -o smtpd_tls_security_level=encrypt" >> /etc/postfix/master.cf
@@ -180,7 +179,6 @@ setup_submission() {
 	    echo "Enable submissions port"
 
 	    echo "smtps inet n       -       n       -       -       smtpd" >> /etc/postfix/master.cf
-	    echo " -o syslog_name=postfix/smtps" >> /etc/postfix/master.cf
 	    echo " -o smtpd_tls_wrappermode=yes" >> /etc/postfix/master.cf
 	    echo " -o smtpd_sasl_auth_enable=no" >> /etc/postfix/master.cf
 	else
@@ -194,7 +192,9 @@ setup_submission() {
 	SMTPD_TLS_CRT=${SMTPD_TLS_CRT:-"/etc/postfix/ssl/certs/tls.crt"}
 	SMTPD_TLS_KEY=${SMTPD_TLS_KEY:-"/etc/postfix/ssl/certs/tls.key"}
 
+	# smtpd_use_tls is deprecated and only for compatibility
 	set_config_value "smtpd_use_tls" "yes"
+	set_config_value "smtpd_tls_security_level" "may"
 	set_config_value "smtpd_tls_CApath" "/etc/ssl/certs"
 	set_config_value "smtpd_tls_cert_file" "${SMTPD_TLS_CRT}"
 	set_config_value "smtpd_tls_key_file" "${SMTPD_TLS_KEY}"
@@ -350,6 +350,10 @@ configure_postfix() {
 	update_db "${i}"
     done
     set_config_value "smtpd_sender_restrictions" "lmdb:/etc/postfix/access"
+
+    # Log to stdout
+    set_config_value "maillog_file" "/dev/stdout"
+
     # Generate and update maps
     update_db access relay relay_recipients
 
@@ -382,28 +386,15 @@ stop_postfix() {
     (   while ! (ps -aux | grep qmgr | grep -v grep | awk '{print $2}' | tr '\n' ' ') > /dev/null 2>&1; do
             ((ms-- <= 0)) && break
             usleep 10000
-        done
-        exec postfix flush
-    ) > /dev/null 2>&1 & 
+	done
+	exec postfix flush
+    ) > /dev/null 2>&1 &
 
     postfix stop
-    terminate /usr/sbin/rsyslogd
 }
 
 stop_daemons() {
     stop_postfix "$@"
-}
-
-start_daemons() {
-    # Don't start syslogd in background while starting it in the background...
-    # Logging to stdout does not work else.
-    echo '# rsyslog configuration file to log to stdout
-    module(load="imuxsock")  # provides support for local system logging (e.g. via logger command)
-
-    *.*                         action(type="omfile" file="/var/log/rsyslog.log")' > /entrypoint/rsyslog-stdout.conf
-    /usr/sbin/rsyslogd -f /entrypoint/rsyslog-stdout.conf -i /var/run/rsyslogd-stdout.pid
-
-    "$@"
 }
 
 #
@@ -412,7 +403,7 @@ start_daemons() {
 
 # if command starts with an option, prepend postfix
 if [ "${1:0:1}" = '-' ]; then
-        set -- postfix start "$@"
+        set -- postfix start-fg "$@"
 fi
 
 init_trap
@@ -427,11 +418,5 @@ configure_postfix
 # before starting services
 rm -f /var/spool/postfix/pid/master.pid
 
-if [ "$1" = 'postfix' ]; then
-    start_daemons "$@"
-    echo "postfix running and ready"
-    echo "[info] refer to postfix manual pages at https://www.postfix.org/postfix-manuals.html"
-    sleep infinity & wait $!
-else
-    exec "$@"
-fi
+exec "$@"
+echo "[info] refer to postfix manual pages at https://www.postfix.org/postfix-manuals.html"

--- a/src/bci_build/package/postfix/entrypoint/sles-entrypoint.patch
+++ b/src/bci_build/package/postfix/entrypoint/sles-entrypoint.patch
@@ -1,53 +1,35 @@
-359,364d358
+363,368d362
 < setup_spamassassin() {
 <     if [ -n "${SPAMASSASSIN_HOST}" ]; then
 < 	set_config_value "smtpd_milters" "unix:/run/spamass-milter/socket"
 <     fi
 < }
 < 
-367c361
+371c365
 <     pid=$(/bin/pidof "$base")
 ---
 >     pid=$(/usr/bin/ps -aux | /usr/bin/grep "$base" | /usr/bin/grep -v grep | /usr/bin/awk '{print $2}' | /usr/bin/tr '\n' ' ')
-383,386d376
+387,390d380
 < stop_spamassassin() {
 <     terminate /usr/sbin/spamass-milter
 < }
 < 
-392c382
+396c386
 <     (   while ! pidof qmgr > /dev/null 2>&1 ; do
 ---
 >     (   while ! (ps -aux | grep qmgr | grep -v grep | awk '{print $2}' | tr '\n' ' ') > /dev/null 2>&1; do
-395,397c385,387
-< 	done
-< 	exec postfix flush
-<     ) > /dev/null 2>&1 &
----
->         done
->         exec postfix flush
->     ) > /dev/null 2>&1 & 
-400c390
-<     terminate /usr/sbin/syslogd
----
->     terminate /usr/sbin/rsyslogd
-405d394
+408d397
 <     stop_spamassassin
-411,417c400,405
-<     /usr/sbin/syslogd -n -S -O - &
+427d415
+< setup_spamassassin
+433,440d420
+< if [ "$1" = 'postfix' ]; then
 <     if [ -n "${SPAMASSASSIN_HOST}" ]; then
 < 	mkdir /run/spamass-milter
 < 	chown sa-milter:postfix /run/spamass-milter
 < 	chmod 751 /run/spamass-milter
 < 	su sa-milter -s /bin/sh -c "/usr/sbin/spamass-milter -p /run/spamass-milter/socket -g postfix -f -- -d ${SPAMASSASSIN_HOST}"
 <     fi
----
->     echo '# rsyslog configuration file to log to stdout
->     module(load="imuxsock")  # provides support for local system logging (e.g. via logger command)
-> 
->     *.*                         action(type="omfile" file="/var/log/rsyslog.log")' > /entrypoint/rsyslog-stdout.conf
->     /usr/sbin/rsyslogd -f /entrypoint/rsyslog-stdout.conf -i /var/run/rsyslogd-stdout.pid
-> 
-437d424
-< setup_spamassassin
-445a433
->     echo "[info] refer to postfix manual pages at https://www.postfix.org/postfix-manuals.html"
+< fi
+441a422
+> echo "[info] refer to postfix manual pages at https://www.postfix.org/postfix-manuals.html"


### PR DESCRIPTION
PR updates the entrypoint for postfix container image with (upstream) changes in https://github.com/thkukuk/containers-mailserver/commit/11d144f9fa673fada91786f5d457f17189bdacc8, which fixes:

```
 /entrypoint/entrypoint.sh: line 411: /usr/sbin/syslogd: No such file or directory
 ``` 

Following above change, another error is introduced:

```
/usr/lib/postfix/bin//postfix-script: line 400: cmp: command not found
```

which will be addressed by SR (postfix package): https://build.opensuse.org/request/show/1192813