### PR TITLE
force enable GNUTLS fips mode too

### DIFF
--- a/src/bci_build/package/basecontainers.py
+++ b/src/bci_build/package/basecontainers.py
@@ -185,6 +185,7 @@ FIPS_BASE_CONTAINERS = [
             ENV OPENSSL_FIPS=1
             ENV OPENSSL_FORCE_FIPS_MODE=1
             ENV LIBGCRYPT_FORCE_FIPS_MODE=1
+            ENV GNUTLS_FORCE_FIPS_MODE=1
             """
         ),
     )


### PR DESCRIPTION
this environment variable will force enable GNUTLS fips mode, if the host is not running FIPS mode.