### PR TITLE
Fix version labels to list the actual language version

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -1448,17 +1448,18 @@ class DevelopmentContainer(BaseContainerImage):
     def build_version(self) -> str | None:
         build_ver = super().build_version
         if build_ver:
-            # if self.version is a numeric version and not a macro, then
+            container_version: str = self.tag_version
+            # if container_version is a numeric version and not a macro, then
             # version.parse() returns a `Version` object => then we concatenate
             # it with the existing build_version
             # for non PEP440 versions, we'll get an exception and just return
             # the parent's classes build_version
             try:
-                version.parse(str(self.version))
+                version.parse(str(container_version))
                 stability_suffix: str = ""
                 if self._stability_suffix:
                     stability_suffix = "." + self._stability_suffix
-                return f"{build_ver}.{self.version}{stability_suffix}"
+                return f"{build_ver}.{container_version}{stability_suffix}"
             except version.InvalidVersion:
                 return build_ver
         return None

--- a/src/bci_build/package/golang.py
+++ b/src/bci_build/package/golang.py
@@ -47,7 +47,9 @@ def _get_golang_kwargs(
         "name": "golang",
         "stability_tag": stability_tag,
         "is_latest": (is_stable and (os_version in CAN_BE_LATEST_OS_VERSION)),
-        "version": f"{ver}{variant}",
+        "tag_version": f"{ver}{variant}",
+        "version": golang_version_regex,
+        "additional_versions": [golang_version_regex],
         "env": {
             "GOLANG_VERSION": golang_version_regex,
             "GOPATH": "/go",

--- a/src/bci_build/package/golang/README.md.j2
+++ b/src/bci_build/package/golang/README.md.j2
@@ -10,7 +10,7 @@ such as garbage collection, type safety, certain dynamic-typing capabilities,
 additional built-in types (for example, variable-length arrays and key-value
 maps) as well as a large standard library.
 
-{%- if image.version.endswith('-openssl') %}
+{%- if image.tag_version.endswith('-openssl') %}
 
 ## FIPS 140-3
 
@@ -126,7 +126,7 @@ the resulting application. See the [SLE BCI use with Go
 documentation](https://opensource.suse.com/bci-docs/guides/use-with-golang/)
 for further details.
 
-{%- if image.version.endswith('-openssl') %}
+{%- if image.tag_version.endswith('-openssl') %}
 
 ## FIPS 140-3
 
@@ -145,7 +145,7 @@ import _ "crypto/tls/fipsonly"
 In addition to the standard SLE BCI development packages, the following tools
 are included in the image:
 
-- go{{ image.version }}-race
+- go{{ image.tag_version }}-race
 - make
 
 {% include 'licensing_and_eula.j2' %}

--- a/src/bci_build/package/node.py
+++ b/src/bci_build/package/node.py
@@ -7,6 +7,7 @@ from bci_build.package import CAN_BE_LATEST_OS_VERSION
 from bci_build.package import _SUPPORTED_UNTIL_SLE
 from bci_build.package import DevelopmentContainer
 from bci_build.package import OsVersion
+from bci_build.package import Replacement
 from bci_build.package import SupportLevel
 
 _NODE_VERSIONS = Literal[16, 18, 20, 21, 22, 23, 24]
@@ -29,6 +30,7 @@ _NODEJS_SUPPORT_ENDS = {
 
 
 def _get_node_kwargs(ver: _NODE_VERSIONS, os_version: OsVersion):
+    node_version_replacement = "%%nodejs_version%%"
     return {
         "name": "nodejs",
         "os_version": os_version,
@@ -38,7 +40,9 @@ def _get_node_kwargs(ver: _NODE_VERSIONS, os_version: OsVersion):
         "package_name": f"nodejs-{ver}-image",
         "pretty_name": f"Node.js {ver} development",
         "additional_names": ["node"],
-        "version": str(ver),
+        "version": node_version_replacement,
+        "tag_version": str(ver),
+        "additional_versions": [node_version_replacement],
         "package_list": [
             f"nodejs{ver}",
             # devel dependencies:
@@ -47,6 +51,12 @@ def _get_node_kwargs(ver: _NODE_VERSIONS, os_version: OsVersion):
             "update-alternatives",
         ]
         + os_version.common_devel_packages,
+        "replacements_via_service": [
+            Replacement(
+                regex_in_build_description=node_version_replacement,
+                package_name=f"nodejs{ver}",
+            ),
+        ],
         "env": {
             "NODE_VERSION": ver,
         },

--- a/src/bci_build/package/python.py
+++ b/src/bci_build/package/python.py
@@ -57,8 +57,9 @@ def _get_python_kwargs(py3_ver: _PYTHON_VERSIONS, os_version: OsVersion):
     kwargs = {
         "name": "python",
         "pretty_name": f"Python {py3_ver} development",
-        "version": py3_ver,
-        "additional_versions": ["3"],
+        "version": py3_ver_replacement,
+        "tag_version": py3_ver,
+        "additional_versions": ["3", py3_ver_replacement],
         "env": {
             "PYTHON_VERSION": py3_ver_replacement,
             "PATH": "$PATH:/root/.local/bin",

--- a/src/bci_build/package/rust.py
+++ b/src/bci_build/package/rust.py
@@ -53,7 +53,9 @@ RUST_CONTAINERS = [
             f"cargo{rust_version}",
         ]
         + os_version.lifecycle_data_pkg,
-        version=rust_version,
+        version="%%RUST_VERSION%%",
+        tag_version=rust_version,
+        additional_versions=["%%RUST_VERSION%%"],
         env={
             "RUST_VERSION": "%%RUST_VERSION%%",
             "CARGO_VERSION": "%%CARGO_VERSION%%",


### PR DESCRIPTION
the org.opencontainer.image.version label should list the actual full version number not our simplified categorization version. set that one as tag_version instead.