### PR TITLE
Use OBS repositories also for docker/podman builds

### DIFF
--- a/src/bci_build/templates.py
+++ b/src/bci_build/templates.py
@@ -27,8 +27,8 @@ You can contact the BCI team via https://github.com/SUSE/bci/discussions
 DOCKERFILE_TEMPLATE = jinja2.Template(
     """# SPDX-License-Identifier: {{ image.license }}
 {{ INFOHEADER }}
-{% if image.exclusive_arch %}#!ExclusiveArch: {% for arch in image.exclusive_arch %}{{ arch }}{{ " " if not loop.last }}{% endfor %}
-{%- endif %}
+#!UseOBSRepositories
+{% if image.exclusive_arch %}#!ExclusiveArch: {% for arch in image.exclusive_arch %}{{ arch }}{{ " " if not loop.last }}{% endfor %}{%- endif %}
 {% for tag in image.build_tags -%}
 #!BuildTag: {{ tag }}
 {% endfor -%}

--- a/tests/test_build_recipe.py
+++ b/tests/test_build_recipe.py
@@ -20,6 +20,7 @@ from bci_build.templates import KIWI_TEMPLATE
         (
             """# SPDX-License-Identifier: MIT
 # Copyright header
+#!UseOBSRepositories
 
 #!BuildTag: bci/test:27
 #!BuildTag: bci/test:27-%RELEASE%
@@ -123,6 +124,7 @@ RUN emacs -Q --batch test.el
         (
             """# SPDX-License-Identifier: MIT
 # Copyright header
+#!UseOBSRepositories
 
 #!BuildTag: bci/test:stable
 #!BuildTag: bci/test:stable-1.%RELEASE%
@@ -221,6 +223,7 @@ LABEL io.artifacthub.package.readme-url="%SOURCEURL%/README.md"
         (
             """# SPDX-License-Identifier: MIT
 # Copyright header
+#!UseOBSRepositories
 
 #!BuildTag: bci/test:29
 #!BuildTag: bci/test:29-%RELEASE%
@@ -318,6 +321,7 @@ USER emacs""",
         (
             """# SPDX-License-Identifier: BSD
 # Copyright header
+#!UseOBSRepositories
 #!ExclusiveArch: x86_64 s390x
 #!BuildTag: opensuse/bci/test:28.2
 #!BuildTag: opensuse/bci/test:28.2-%RELEASE%


### PR DESCRIPTION
This was already set for kiwi, however for docker we fell back to default repositories which are the repositories of the base container which could be different (they are when building against a released base container from the SUSE:Registry)