### PR TITLE
Remove :latest tag from SLE16_0 containers

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -305,7 +305,6 @@ ALL_OS_VERSIONS: set[OsVersion] = {
 CAN_BE_LATEST_OS_VERSION: list[OsVersion] = [
     OsVersion.SP6,
     OsVersion.TUMBLEWEED,
-    OsVersion.SLE16_0,
 ]
 
 


### PR DESCRIPTION
SLE 16 is not yet released, so we don't want latest tag on them