### PR TITLE
Make the last stage a fully qualified reference to the registry

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -686,6 +686,13 @@ class BaseContainerImage(abc.ABC):
         return "SUSE LLC"
 
     @property
+    def base_image_registry(self) -> str:
+        """The registry where the base image is available on."""
+        if self.os_version.is_tumbleweed:
+            return "registry.opensuse.org"
+        return "registry.suse.com"
+
+    @property
     def registry(self) -> str:
         """The registry where the image is available on."""
         if self.os_version.is_tumbleweed:
@@ -823,7 +830,7 @@ exit 0
 
         if self.from_target_image:
             return (
-                f"FROM {self.from_target_image} AS target\n"
+                f"FROM {self.base_image_registry}/{self.from_target_image} AS target\n"
                 f"FROM {self._from_image} AS builder"
             )
 

--- a/src/bci_build/package/apache_tomcat.py
+++ b/src/bci_build/package/apache_tomcat.py
@@ -127,6 +127,7 @@ WORKDIR $CATALINA_HOME
         (10, OsVersion.TUMBLEWEED, 17),
         (9, OsVersion.TUMBLEWEED, 17),
         (10, OsVersion.SP6, 21),
-        (10, OsVersion.SP7, 21),
+        # can't build for SP7 yet because base container is not yet released
+        # (10, OsVersion.SP7, 21),
     )
 ]

--- a/src/bci_build/templates.py
+++ b/src/bci_build/templates.py
@@ -44,7 +44,7 @@ COPY --from=target / /target
 {%- endif %}
 
 {% if image.packages %}{{ DOCKERFILE_RUN }} zypper{% if image.from_target_image %} --installroot /target --gpg-auto-import-keys {% endif %} -n in {% if image.no_recommends %}--no-recommends {% endif %}{{ image.packages }}; zypper -n clean; {{ LOG_CLEAN }}{% endif %}
-{% if image.from_target_image %}FROM target
+{% if image.from_target_image %}FROM {{ image.base_image_registry }}/{{ image.from_target_image }}
 COPY --from=builder /target /{% endif %}
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix={{ image.labelprefix }}

--- a/src/staging/project_setup.py
+++ b/src/staging/project_setup.py
@@ -36,25 +36,31 @@ META_TEMPLATE = jinja2.Template("""<project name="{{ project_name }}">
 {% for prj, repo in repository_paths %}    <path project="{{ prj }}" repository="{{ repo }}"/>
 {% endfor %}    <arch>x86_64</arch>
     <arch>aarch64</arch>
-{% if with_all_arches %}    <arch>s390x</arch>
-    <arch>ppc64le</arch>{% endif %}
+{%- if with_all_arches %}
+    <arch>s390x</arch>
+    <arch>ppc64le</arch>
+{%- endif %}
   </repository>
   <repository name="images">
     <path project="{{ project_name }}" repository="containerfile"/>
     <path project="{{ project_name }}" repository="standard"/>
     <arch>x86_64</arch>
-    <arch>aarch64</arch>{% if with_all_arches %}
+    <arch>aarch64</arch>
+{%- if with_all_arches %}
     <arch>s390x</arch>
-    <arch>ppc64le</arch>{% endif %}
+    <arch>ppc64le</arch>
+{%- endif %}
   </repository>{% if with_product_repo %}
   <repository name="product">
     <path project="{{ project_name }}" repository="containerfile"/>
     <path project="{{ project_name }}" repository="images"/>
     <path project="{{ project_name }}" repository="standard"/>
     <arch>x86_64</arch>
-    <arch>aarch64</arch>{% if with_all_arches %}
+    <arch>aarch64</arch>
+{%- if with_all_arches %}
     <arch>s390x</arch>
-    <arch>ppc64le</arch>{% endif %}
+    <arch>ppc64le</arch>
+{%- endif %}
   </repository>{% endif %}{% if with_helmcharts_repo %}
   <repository name="helmcharts">
     <path project="{{ project_name }}" repository="standard"/>
@@ -64,9 +70,11 @@ META_TEMPLATE = jinja2.Template("""<project name="{{ project_name }}">
     <path project="{{ project_name }}" repository="images"/>
     <path project="{{ project_name }}" repository="standard"/>
     <arch>x86_64</arch>
-    <arch>aarch64</arch>{% if with_all_arches %}
+    <arch>aarch64</arch>
+{%- if with_all_arches %}
     <arch>s390x</arch>
-    <arch>ppc64le</arch>{% endif %}
+    <arch>ppc64le</arch>
+{%- endif %}
   </repository>
 </project>
 """)

--- a/src/staging/project_setup.py
+++ b/src/staging/project_setup.py
@@ -152,6 +152,7 @@ def generate_meta(
     else:
         assert os_version.is_tumbleweed
         repository_paths = (
+            ("openSUSE:Registry", "standard"),
             ("openSUSE:Factory", "images"),
             ("openSUSE:Factory:ARM", "images"),
             ("openSUSE:Factory:ARM", "standard"),

--- a/tests/test_project_setup.py
+++ b/tests/test_project_setup.py
@@ -280,6 +280,52 @@ _OSC_USERNAME = "foobar"
   </repository>
 </project>""",
         ),
+        (
+            OsVersion.TUMBLEWEED,
+            ProjectType.STAGING,
+            (branch := "7-777"),
+            (prj_name := f"home:{_OSC_USERNAME}:BCI:Staging:Tumbleweed:{branch}"),
+            f"""<project name="{prj_name}">
+  <title>Staging project for openSUSE Tumbleweed</title>
+  <description>Staging project for https://github.com/SUSE/BCI-dockerfile-generator/tree/{branch} for openSUSE Tumbleweed</description>
+  <person userid="avicenzi" role="maintainer"/>
+  <person userid="dancermak" role="maintainer"/>
+  <person userid="{_OSC_USERNAME}" role="maintainer"/>
+
+  <build>
+    <enable/>
+  </build>
+  <publish>
+    <enable/>
+  </publish>
+  <debuginfo>
+    <enable/>
+  </debuginfo>
+  <repository name="standard">
+    <path project="openSUSE:Registry" repository="standard"/>
+    <path project="openSUSE:Factory" repository="images"/>
+    <path project="openSUSE:Factory:ARM" repository="images"/>
+    <path project="openSUSE:Factory:ARM" repository="standard"/>
+    <path project="openSUSE:Factory:PowerPC" repository="standard"/>
+    <path project="openSUSE:Factory:zSystems" repository="standard"/>
+    <path project="openSUSE:Factory" repository="snapshot"/>
+    <arch>x86_64</arch>
+    <arch>aarch64</arch>
+  </repository>
+  <repository name="images">
+    <path project="{prj_name}" repository="containerfile"/>
+    <path project="{prj_name}" repository="standard"/>
+    <arch>x86_64</arch>
+    <arch>aarch64</arch>
+  </repository>
+  <repository name="containerfile">
+    <path project="{prj_name}" repository="images"/>
+    <path project="{prj_name}" repository="standard"/>
+    <arch>x86_64</arch>
+    <arch>aarch64</arch>
+  </repository>
+</project>""",
+        ),
     ],
 )
 def test_project_meta(


### PR DESCRIPTION
Although "FROM target" works, it does not generate the necessary annotations as buildah/podman can not trace it back to the original layer.