### PR TITLE
Install sles-release with coreutils

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -261,8 +261,6 @@ class OsVersion(enum.Enum):
             return ("SLES-release",)
         if self.is_ltss:
             return ("sles-ltss-release",)
-        # if self.is_slcc:
-        #     return (f"{str(self.value).lower()}-release",)
 
         assert self.is_sle15
         return ("sles-release",)

--- a/src/bci_build/package/basecontainers.py
+++ b/src/bci_build/package/basecontainers.py
@@ -170,7 +170,7 @@ FIPS_BASE_CONTAINERS = [
         supported_until=_get_supported_until_fips(os_version),
         is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
         pretty_name=_get_fips_pretty_name(os_version),
-        package_list=[*os_version.release_package_names]
+        package_list=[*os_version.release_package_names, "coreutils"]
         + (
             ["fipscheck"]
             if os_version == OsVersion.SP3

--- a/src/dotnet/updater.py
+++ b/src/dotnet/updater.py
@@ -91,7 +91,7 @@ COPY {{ pkg.name }} /tmp/
 {% endfor %}
 
 # Workaround for https://github.com/openSUSE/obs-build/issues/487
-RUN zypper --non-interactive install --no-recommends sles-release
+RUN zypper --non-interactive install --no-recommends coreutils sles-release
 
 # Importing MS GPG keys
 COPY microsoft.asc /tmp


### PR DESCRIPTION
the sles-release on sle15 has a requires on coreutils or busybox-coreutils. We don't want to default to busybox so explicitly require coreutils.