### PR TITLE
Fix container version of SLE 16 to :16.0 and don't use :latest

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -1496,8 +1496,10 @@ class ApplicationStackContainer(DevelopmentContainer):
 class OsContainer(BaseContainerImage):
     @staticmethod
     def version_to_container_os_version(os_version: OsVersion) -> str:
-        if os_version in (OsVersion.TUMBLEWEED, OsVersion.SLE16_0):
+        if os_version == OsVersion.TUMBLEWEED:
             return "latest"
+        if os_version == OsVersion.SLE16_0:
+            return str(os_version)
         return f"15.{os_version}"
 
     @property


### PR DESCRIPTION
With 491c2d67ac60d107810be3051735313b716d0a5f we removed the latest tag from SLE 16 based containers, hence `FROM bci/bci-micro:latest` is now broken for SLE 16 and we have to specify the exact version