### PR TITLE
remove %RELEASE% suffixed tags for the additional_versions

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -1444,11 +1444,14 @@ class DevelopmentContainer(BaseContainerImage):
             ver_labels: list[str] = [self.tag_version]
             if self.stability_tag:
                 ver_labels = [self.stability_tag] + ver_labels
-            for ver_label in ver_labels + self.additional_versions:
+            for ver_label in ver_labels:
                 tags += [f"{self._registry_prefix}/{name}:{ver_label}"]
                 tags += [
                     f"{self._registry_prefix}/{name}:{ver_label}-{self._release_suffix}"
                 ]
+            for ver_label in self.additional_versions:
+                tags += [f"{self._registry_prefix}/{name}:{ver_label}"]
+
             if self.is_latest:
                 tags += [f"{self._registry_prefix}/{name}:latest"]
         return tags

--- a/tests/test_build_recipe.py
+++ b/tests/test_build_recipe.py
@@ -340,12 +340,10 @@ Copyright header
 #!BuildTag: opensuse/bci/test:28.2
 #!BuildTag: opensuse/bci/test:28.2-%RELEASE%
 #!BuildTag: opensuse/bci/test:28
-#!BuildTag: opensuse/bci/test:28-%RELEASE%
 #!BuildTag: opensuse/bci/test:latest
 #!BuildTag: opensuse/bci/emacs:28.2
 #!BuildTag: opensuse/bci/emacs:28.2-%RELEASE%
 #!BuildTag: opensuse/bci/emacs:28
-#!BuildTag: opensuse/bci/emacs:28-%RELEASE%
 #!BuildTag: opensuse/bci/emacs:latest
 
 FROM suse/base:18
@@ -385,7 +383,7 @@ VOLUME /bin/ /usr/bin/""",
 <!--
 Copyright header
 -->
-<!-- OBS-AddTag: opensuse/bci/test:28.2 opensuse/bci/test:28.2-%RELEASE% opensuse/bci/test:28 opensuse/bci/test:28-%RELEASE% opensuse/bci/test:latest opensuse/bci/emacs:28.2 opensuse/bci/emacs:28.2-%RELEASE% opensuse/bci/emacs:28 opensuse/bci/emacs:28-%RELEASE% opensuse/bci/emacs:latest -->
+<!-- OBS-AddTag: opensuse/bci/test:28.2 opensuse/bci/test:28.2-%RELEASE% opensuse/bci/test:28 opensuse/bci/test:latest opensuse/bci/emacs:28.2 opensuse/bci/emacs:28.2-%RELEASE% opensuse/bci/emacs:28 opensuse/bci/emacs:latest -->
 <!-- OBS-ExclusiveArch: x86_64 s390x -->
 <!-- OBS-Imagerepo: obsrepositories:/ -->
 
@@ -400,7 +398,7 @@ Copyright header
       <containerconfig
           name="opensuse/bci/test"
           tag="28.2"
-          additionaltags="28.2-%RELEASE%,28,28-%RELEASE%,latest">
+          additionaltags="28.2-%RELEASE%,28,latest">
         <labels>
           <suse_label_helper:add_prefix prefix="org.opensuse.bci.test">
             <label name="org.opencontainers.image.authors" value="invalid@suse.com"/>


### PR DESCRIPTION
This partially reverts cb350c0b2f9efbb7694ed00f2cbf913fa49a88ca which didn't really have a description on why it was done. Removing them is a requisite for appcol listing.