### PR TITLE
Make image.reference optional and hide it for appcollection

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -1028,7 +1028,7 @@ exit 0
 
     @property
     @abc.abstractmethod
-    def reference(self) -> str:
+    def reference(self) -> str | None:
         """The primary URL via which this image can be pulled. It is used to set the
         ``org.opensuse.reference`` label and defaults to
         ``{self.registry}/{self.image_ref_name}``.
@@ -1435,7 +1435,7 @@ class DevelopmentContainer(BaseContainerImage):
         return f"{self.tag_version}-{self._release_suffix}"
 
     @property
-    def reference(self) -> str:
+    def reference(self) -> str | None:
         return (
             f"{self.registry}/{self._registry_prefix}/{self.name}:{self.image_ref_name}"
         )
@@ -1536,7 +1536,7 @@ class OsContainer(BaseContainerImage):
         return self.oci_version
 
     @property
-    def reference(self) -> str:
+    def reference(self) -> str | None:
         return f"{self.registry}/{self._registry_prefix}/bci-{self.name}:{self.image_ref_name}"
 
     @property

--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -1032,6 +1032,8 @@ exit 0
         """The primary URL via which this image can be pulled. It is used to set the
         ``org.opensuse.reference`` label and defaults to
         ``{self.registry}/{self.image_ref_name}``.
+        
+        The ``org.opensuse.reference`` label is omitted, if ``None`` is returned.
 
         """
         pass

--- a/src/bci_build/package/appcollection.py
+++ b/src/bci_build/package/appcollection.py
@@ -42,6 +42,12 @@ class ApplicationCollectionContainer(ApplicationStackContainer):
 
         return f"bci/bci-base:15.{self.os_version}"
 
+    @property
+    def reference(self) -> str | None:
+        if self.os_version.is_tumbleweed:
+            return super().reference
+        return None
+
     def __post_init__(self) -> None:
         super().__post_init__()
         # Limit Appcollection stuff to aarch64 and x86_64

--- a/src/bci_build/templates.py
+++ b/src/bci_build/templates.py
@@ -57,7 +57,9 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 LABEL org.opencontainers.image.vendor="{{ image.vendor }}"
 LABEL org.opencontainers.image.source="%SOURCEURL%"
 LABEL org.opencontainers.image.ref.name="{{ image.image_ref_name }}"
+{%- if image.reference %}
 LABEL org.opensuse.reference="{{ image.reference }}"
+{%- endif %}
 LABEL org.openbuildservice.disturl="%DISTURL%"
 {%- if image.os_version.is_tumbleweed %}
 LABEL org.opensuse.lifecycle-url="{{ image.lifecycle_url }}"
@@ -134,7 +136,9 @@ KIWI_TEMPLATE = jinja2.Template(
             <label name="org.opencontainers.image.source" value="%SOURCEURL%"/>
             <label name="org.opencontainers.image.url" value="{{ image.url }}"/>
             <label name="org.opencontainers.image.ref.name" value="{{ image.image_ref_name }}"/>
+{%- if image.reference %}
             <label name="org.opensuse.reference" value="{{ image.reference }}"/>
+{%- endif %}
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
 {%- if not image.os_version.is_tumbleweed %}
             <label name="com.suse.supportlevel" value="{{ image.support_level }}"/>


### PR DESCRIPTION
It was requested to not refer to opensuse in the Rancher AppCol.