### PR TITLE
Only disable maintainer listing on SLE

### DIFF
--- a/src/bci_build/package/appcollection.py
+++ b/src/bci_build/package/appcollection.py
@@ -47,5 +47,7 @@ class ApplicationCollectionContainer(ApplicationStackContainer):
         # Limit Appcollection stuff to aarch64 and x86_64
         if not self.os_version.is_tumbleweed and not self.exclusive_arch:
             self.exclusive_arch = [Arch.AARCH64, Arch.X86_64]
-        # Disable maintainer listing
-        self.maintainer = None
+
+        # Disable maintainer listing for SLE
+        if not self.os_version.is_tumbleweed:
+            self.maintainer = None


### PR DESCRIPTION
For openSUSE we won't be publishing to apps.rancher.io, so we can keep this label for registry.opensuse.org