### PR TITLE
Install openssl-3 in the base container

### DIFF
--- a/src/bci_build/package/base.py
+++ b/src/bci_build/package/base.py
@@ -148,6 +148,7 @@ def _get_base_kwargs(os_version: OsVersion) -> dict:
                     "curl",
                     "gzip",
                     "netcfg",
+                    "openssl-3",
                     "tar",
                     "timezone",
                     *os_version.eula_package_names,


### PR DESCRIPTION
15.6+ want the "openssl" cli command in the testsuite, so install it explicitly.