### PR TITLE
Add compat symlink to /usr/local/tomcat

### DIFF
--- a/src/bci_build/package/apache_tomcat.py
+++ b/src/bci_build/package/apache_tomcat.py
@@ -101,7 +101,8 @@ TOMCAT_CONTAINERS = [
             "CATALINA_BASE": _CATALINA_HOME,
             "PATH": f"{_CATALINA_HOME}/bin:$PATH",
         },
-        custom_end=rf"""{DOCKERFILE_RUN} mkdir -p /var/log/tomcat; chown --recursive tomcat:tomcat /var/log/tomcat;
+        custom_end=rf"""{DOCKERFILE_RUN} mkdir -p /var/log/tomcat; chown --recursive tomcat:tomcat /var/log/tomcat
+{DOCKERFILE_RUN} ln -s {_CATALINA_HOME} /usr/local/tomcat
 {DOCKERFILE_RUN} \
     sed -i /etc/tomcat/logging.properties \
         -e 's|org\.apache\.catalina\.core\.ContainerBase\.\[Catalina\]\.\[localhost\]\.handlers =.*|org.apache.catalina.core.ContainerBase.[Catalina].[localhost].handlers = java.util.logging.ConsoleHandler|' \


### PR DESCRIPTION
This is an improved compatibility with upstream in case somebody is not mounting via the $CATALINA_HOME env variable