### PR TITLE
Remove util-linux from the tomcat containers

### DIFF
--- a/src/bci_build/package/apache_tomcat.py
+++ b/src/bci_build/package/apache_tomcat.py
@@ -6,6 +6,8 @@ from bci_build.package import CAN_BE_LATEST_OS_VERSION
 from bci_build.package import DOCKERFILE_RUN
 from bci_build.package import OsContainer
 from bci_build.package import OsVersion
+from bci_build.package import Package
+from bci_build.package import PackageType
 from bci_build.package import Replacement
 from bci_build.package import _build_tag_prefix
 
@@ -82,6 +84,7 @@ TOMCAT_CONTAINERS = [
             "curl",
             # currently needed by custom_end
             "sed",
+            Package("util-linux", PackageType.DELETE),
         ]
         + [f"java-{jre_version}-openjdk", f"java-{jre_version}-openjdk-headless"],
         replacements_via_service=[

--- a/src/bci_build/templates.py
+++ b/src/bci_build/templates.py
@@ -43,7 +43,14 @@ DOCKERFILE_TEMPLATE = jinja2.Template(
 COPY --from=target / /target
 {%- endif %}
 
-{% if image.packages %}{{ DOCKERFILE_RUN }} zypper{% if image.from_target_image %} --installroot /target --gpg-auto-import-keys {% endif %} -n in {% if image.no_recommends %}--no-recommends {% endif %}{{ image.packages }}; zypper -n clean; {{ LOG_CLEAN }}{% endif %}
+{% if image.packages %}{{ DOCKERFILE_RUN }} \\
+    zypper -n {%- if image.from_target_image %} --installroot /target --gpg-auto-import-keys {%- endif %} install {% if image.no_recommends %}--no-recommends {% endif %}{{ image.packages }}; \\
+    {%- if image.packages_to_delete %}
+    zypper -n {%- if image.from_target_image %} --installroot /target {%- endif %} remove {{ image.packages_to_delete }}; \\
+    {%- endif %}
+    zypper -n clean; \\
+    {{ LOG_CLEAN }}
+{%- endif %}
 {% if image.from_target_image %}FROM {{ image.dockerfile_from_target_ref }}
 COPY --from=builder /target /{% endif %}
 # Define labels according to https://en.opensuse.org/Building_derived_containers

--- a/tests/test_build_recipe.py
+++ b/tests/test_build_recipe.py
@@ -30,7 +30,10 @@ from bci_build.templates import KIWI_TEMPLATE
 #!BuildVersion: 15.6.27
 FROM bci/bci-base:15.6
 
-RUN zypper -n in --no-recommends gcc emacs; zypper -n clean; ##LOGCLEAN##
+RUN \\
+    zypper -n install --no-recommends gcc emacs; \\
+    zypper -n clean; \\
+    ##LOGCLEAN##
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=com.suse.bci.test
@@ -140,7 +143,10 @@ RUN emacs -Q --batch test.el
 #!BuildVersion: 15.5
 FROM bci/bci-base:15.5
 
-RUN zypper -n in --no-recommends gcc emacs; zypper -n clean; ##LOGCLEAN##
+RUN \\
+    zypper -n install --no-recommends gcc emacs; \\
+    zypper -n clean; \\
+    ##LOGCLEAN##
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=com.suse.bci.test
@@ -241,7 +247,10 @@ Copyright header
 #!BuildVersion: 15.6.29
 FROM bci/bci-base:15.6
 
-RUN zypper -n in --no-recommends gcc emacs; zypper -n clean; ##LOGCLEAN##
+RUN \\
+    zypper -n install --no-recommends gcc emacs; \\
+    zypper -n clean; \\
+    ##LOGCLEAN##
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=com.suse.bci.test
@@ -348,7 +357,10 @@ Copyright header
 
 FROM suse/base:18
 
-RUN zypper -n in --no-recommends gcc emacs; zypper -n clean; ##LOGCLEAN##
+RUN \\
+    zypper -n install --no-recommends gcc emacs; \\
+    zypper -n clean; \\
+    ##LOGCLEAN##
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=org.opensuse.bci.test


### PR DESCRIPTION
This is only needed for the runuser command in the post script and not needed in the final container.