### PR TITLE
Build the apache-tomcat containers as build_flavors

### DIFF
--- a/src/bci_build/containercrate.py
+++ b/src/bci_build/containercrate.py
@@ -1,0 +1,39 @@
+"""Crate to handle multibuild containers in the generator."""
+
+
+class ContainerCrate:
+    """ContainerCrate is combining multiple container build flavors.
+
+    This provides package-central functions like generating _service and
+    _multibuild files.
+    """
+
+    def __init__(self, containers: list):
+        """Assign the crate for every container."""
+        self._all_build_flavors: dict[tuple, set] = {}
+        for container in containers:
+            if container.build_flavor:
+                self._all_build_flavors.setdefault(
+                    (container.os_version, container.package_name), set()
+                ).add(container.build_flavor)
+
+        for container in containers:
+            if container.crate is not None:
+                raise ValueError("Container is already part of a ContainerCrate")
+            container.crate = self
+
+    def all_build_flavors(self, container):
+        """Return all build flavors for this container in the crate"""
+        return sorted(
+            self._all_build_flavors.get(
+                (container.os_version, container.package_name), [""]
+            )
+        )
+
+    def multibuild(self, container):
+        """Return the _multibuild file string to write for this ContainerCrate."""
+        flavors: str = "\n".join(
+            " " * 4 + f"<package>{pkg}</package>"
+            for pkg in self.all_build_flavors(container)
+        )
+        return f"<multibuild>\n{flavors}\n</multibuild>"

--- a/src/bci_build/package/apache_tomcat.py
+++ b/src/bci_build/package/apache_tomcat.py
@@ -2,6 +2,7 @@
 
 import datetime
 
+from bci_build.containercrate import ContainerCrate
 from bci_build.package import CAN_BE_LATEST_OS_VERSION
 from bci_build.package import DOCKERFILE_RUN
 from bci_build.package import OsContainer
@@ -52,9 +53,9 @@ def _get_sac_supported_until(
 TOMCAT_CONTAINERS = [
     ApplicationCollectionContainer(
         name="apache-tomcat",
-        package_name=f"apache-tomcat-{tomcat_ver.partition('.')[0]}-java-{jre_version}-image"
+        package_name=f"apache-tomcat-{tomcat_ver.partition('.')[0]}-image"
         if os_version.is_tumbleweed
-        else f"sac-apache-tomcat-{tomcat_ver.partition('.')[0]}-java{jre_version}-image",
+        else f"sac-apache-tomcat-{tomcat_ver.partition('.')[0]}-image",
         pretty_name="Apache Tomcat",
         custom_description=(
             "Apache Tomcat is a free and open-source implementation of the Jakarta Servlet, "
@@ -73,6 +74,7 @@ TOMCAT_CONTAINERS = [
         supported_until=_get_sac_supported_until(
             os_version=os_version, tomcat_ver=tomcat_ver, jre_major=jre_version
         ),
+        build_flavor=f"openjdk{jre_version}",
         additional_versions=[f"%%tomcat_version%%-openjdk{jre_version}"],
         from_target_image=f"{_build_tag_prefix(os_version)}/bci-micro:{OsContainer.version_to_container_os_version(os_version)}",
         package_list=[
@@ -124,6 +126,9 @@ WORKDIR $CATALINA_HOME
         ("10.1", OsVersion.TUMBLEWEED, 17),
         ("9", OsVersion.TUMBLEWEED, 17),
         ("10.1", OsVersion.SP6, 21),
+        ("10.1", OsVersion.SP6, 17),
         # (10.1, OsVersion.SP7, 21),
     )
 ]
+
+TOMCAT_CRATE = ContainerCrate(TOMCAT_CONTAINERS)

--- a/src/bci_build/templates.py
+++ b/src/bci_build/templates.py
@@ -194,13 +194,24 @@ SERVICE_TEMPLATE = jinja2.Template(
     """<services>
   <service mode="buildtime" name="{{ image.build_recipe_type }}_label_helper"/>
   <service mode="buildtime" name="kiwi_metainfo_helper"/>
+{%- set all_build_flavors = [""] %}
+{%-     if image.crate and image.build_flavor %}
+{%-         set all_build_flavors = image.crate.all_build_flavors(image) %}
+{%-     endif %}
+{%- for flavor in all_build_flavors %}
 {%- for replacement in image.replacements_via_service %}
   <service name="replace_using_package_version" mode="buildtime">
-    <param name="file">{% if replacement.file_name != None %}{{replacement.file_name}}{% elif (image.build_recipe_type|string) == "docker" %}Dockerfile{% else %}{{ image.package_name }}.kiwi{% endif %}</param>
+    <param name="file">
+{%- if replacement.file_name != None %}{{replacement.file_name}}
+{%- elif (image.build_recipe_type|string) == "docker" %}{% if flavor %}Dockerfile.{{ flavor }}{% else %}Dockerfile{% endif %}
+{%- else %}{{ image.package_name }}.kiwi
+{%- endif %}</param>
     <param name="regex">{{ replacement.regex_in_build_description }}</param>
     <param name="package">{{ replacement.package_name }}</param>{% if replacement.parse_version %}
     <param name="parse-version">{{ replacement.parse_version }}</param>{% endif %}
-  </service>{% endfor %}
+  </service>
+{%- endfor -%}
+{% endfor %}
 </services>
 """
 )

--- a/src/staging/bot.py
+++ b/src/staging/bot.py
@@ -765,23 +765,18 @@ PACKAGES={','.join(self.package_names) if self.package_names else None}
                 will be added
 
         """
-        tasks = [
-            self._write_pkg_meta(
-                bci,
-                git_branch_name=git_branch_name,
-                target_obs_project=target_obs_project,
-            )
-            for bci in packages
-        ]
-
+        tasks = []
+        pkg_metas_to_generate = set()
         for bci in packages:
-            tasks.append(
-                self._write_pkg_meta(
-                    bci,
-                    git_branch_name=git_branch_name,
-                    target_obs_project=target_obs_project,
+            if bci.package_name not in pkg_metas_to_generate:
+                pkg_metas_to_generate.add(bci.package_name)
+                tasks.append(
+                    self._write_pkg_meta(
+                        bci,
+                        git_branch_name=git_branch_name,
+                        target_obs_project=target_obs_project,
+                    )
                 )
-            )
 
         await asyncio.gather(*tasks)
 

--- a/tests/test_crate.py
+++ b/tests/test_crate.py
@@ -1,0 +1,31 @@
+from bci_build.containercrate import ContainerCrate
+from bci_build.package import BuildType
+from bci_build.package import DevelopmentContainer
+from bci_build.package import OsVersion
+
+_BASE_KWARGS = {
+    "name": "test",
+    "package_name": "test-image",
+    "pretty_name": "Test",
+    "os_version": OsVersion.SP3,
+    "package_list": ["sh"],
+    "version": "1.0",
+}
+
+
+def test_multibuild_with_multi_flavor_docker():
+    containers = [
+        DevelopmentContainer(
+            **_BASE_KWARGS,
+            build_recipe_type=BuildType.DOCKER,
+            build_flavor=flavor,
+        )
+        for flavor in ("flavor1", "flavor2")
+    ]
+    assert (
+        ContainerCrate(containers).multibuild(containers[0])
+        == """<multibuild>
+    <package>flavor1</package>
+    <package>flavor2</package>
+</multibuild>"""
+    )


### PR DESCRIPTION
This allows to sync the -RELEASE tag between multiple flavors, which is a requirement for appcollection.

For now all the build_flavors need to be manually passed in for _multibuild and _service generation. This could be eventually replaced by more automagic later on.