### PR TITLE
Change KIWI application builds to build against released containers

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -874,10 +874,13 @@ exit 0
     def kiwi_derived_from_entry(self) -> str:
         if self._from_image is None:
             return ""
-        # Adjust for the absolutely braindamaged format that OBS expects to reference
+        # Adjust for the special format that OBS expects to reference
         # external images
         if self.is_base_container_annotation_available:
-            return f" derived_from=\"obs://SUSE:Registry/standard/{self._from_image.replace('registry.suse.com/','').replace(':', '#')}\""
+            repo: str = self._from_image.replace("registry.suse.com/", "").replace(
+                ":", "#"
+            )
+            return f' derived_from="obs://SUSE:Registry/standard/{repo}"'
         return (
             f" derived_from=\"obsrepositories:/{self._from_image.replace(':', '#')}\""
         )

--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -848,8 +848,14 @@ exit 0
     @property
     def is_base_container_annotation_available(self) -> bool:
         """return True if the obs-service-kiwi_metainfo_helper can provide base.name/digest annotations."""
+        _from_image = self._from_image
         return bool(
-            self._from_image
+            _from_image
+            and self.os_version in RELEASED_OS_VERSIONS
+            and (
+                self.from_target_image
+                or _from_image.startswith(self.base_image_registry)
+            )
             and not self.os_version.is_tumbleweed
             and not self.os_version.is_slfo  # waiting for ibs#345975
         )
@@ -868,6 +874,10 @@ exit 0
     def kiwi_derived_from_entry(self) -> str:
         if self._from_image is None:
             return ""
+        # Adjust for the absolutely braindamaged format that OBS expects to reference
+        # external images
+        if self.is_base_container_annotation_available:
+            return f" derived_from=\"obs://SUSE:Registry/standard/{self._from_image.replace('registry.suse.com/','').replace(':', '#')}\""
         return (
             f" derived_from=\"obsrepositories:/{self._from_image.replace(':', '#')}\""
         )

--- a/src/bci_build/package/appcontainers.py
+++ b/src/bci_build/package/appcontainers.py
@@ -15,6 +15,7 @@ from bci_build.package import ParseVersion
 from bci_build.package import Replacement
 from bci_build.package import SupportLevel
 from bci_build.package import _build_tag_prefix
+from bci_build.package.helpers import generate_from_image
 from bci_build.package.helpers import generate_package_version_check
 from bci_build.package.versions import format_version
 from bci_build.package.versions import get_pkg_version
@@ -350,7 +351,7 @@ GIT_CONTAINERS = [
         support_level=SupportLevel.L3,
         pretty_name=f"{os_version.pretty_os_version_no_dash} with Git",
         custom_description="A micro environment with Git {based_on_container}.",
-        from_image=f"{_build_tag_prefix(os_version)}/bci-micro:{OsContainer.version_to_container_os_version(os_version)}",
+        from_image=generate_from_image(os_version, "bci-micro"),
         build_recipe_type=BuildType.KIWI,
         is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
         version="%%git_version%%",
@@ -395,7 +396,7 @@ REGISTRY_CONTAINERS = [
         name="registry",
         package_name="distribution-image",
         pretty_name="OCI Container Registry (Distribution)",
-        from_image=f"{_build_tag_prefix(os_version)}/bci-micro:{OsContainer.version_to_container_os_version(os_version)}",
+        from_image=generate_from_image(os_version, "bci-micro"),
         os_version=os_version,
         is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
         version="%%registry_version%%",
@@ -434,7 +435,7 @@ HELM_CONTAINERS = [
     ApplicationStackContainer(
         name="helm",
         pretty_name="Kubernetes Package Manager",
-        from_image=f"{_build_tag_prefix(os_version)}/bci-micro:{OsContainer.version_to_container_os_version(os_version)}",
+        from_image=generate_from_image(os_version, "bci-micro"),
         os_version=os_version,
         is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
         version=get_pkg_version("helm", os_version),
@@ -460,7 +461,7 @@ TRIVY_CONTAINERS = [
     ApplicationStackContainer(
         name="trivy",
         pretty_name="Container Vulnerability Scanner",
-        from_image=f"{_build_tag_prefix(os_version)}/bci-micro:{OsContainer.version_to_container_os_version(os_version)}",
+        from_image=generate_from_image(os_version, "bci-micro"),
         os_version=os_version,
         is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
         version="%%trivy_version%%",

--- a/src/bci_build/package/helpers.py
+++ b/src/bci_build/package/helpers.py
@@ -1,5 +1,8 @@
 from bci_build.package import DOCKERFILE_RUN
+from bci_build.package import RELEASED_OS_VERSIONS
+from bci_build.package import OsContainer
 from bci_build.package import ParseVersion
+from bci_build.package import _build_tag_prefix
 
 
 def generate_package_version_check(
@@ -25,3 +28,10 @@ def generate_package_version_check(
 
     return f"""# sanity check that the version from the tag is equal to the version of {pkg_name} that we expect
 {DOCKERFILE_RUN} [ "$(rpm -q --qf '%{{version}}' {pkg_name} | cut -d '.' -f -{cut_count})" = "{pkg_version}" ]"""
+
+
+def generate_from_image(os_version, container_name) -> str:
+    repo = f"{_build_tag_prefix(os_version)}/{container_name}:{OsContainer.version_to_container_os_version(os_version)}"
+    if not os_version.is_tumbleweed and os_version in RELEASED_OS_VERSIONS:
+        return f"registry.suse.com/{repo}"
+    return repo

--- a/tests/test_build_recipe.py
+++ b/tests/test_build_recipe.py
@@ -28,7 +28,7 @@ from bci_build.templates import KIWI_TEMPLATE
 #!BuildTag: bci/test:27-%RELEASE%
 #!BuildName: bci-test-27
 #!BuildVersion: 15.6.27
-FROM bci/bci-base:15.6
+FROM registry.suse.com/bci/bci-base:15.6
 
 RUN \\
     zypper -n install --no-recommends gcc emacs; \\
@@ -75,7 +75,7 @@ Copyright header
     <specification>SLE BCI Test Container Image</specification>
   </description>
   <preferences>
-    <type image="docker" derived_from="obsrepositories:/bci/bci-base#15.6">
+    <type image="docker" derived_from="obs://SUSE:Registry/standard/bci/bci-base#15.6">
       <containerconfig
           name="bci/test"
           tag="27"
@@ -145,7 +145,7 @@ RUN emacs -Q --batch test.el
 #!BuildTag: bci/test:%%emacs_ver%%-1.%RELEASE%
 #!BuildName: bci-test-stable
 #!BuildVersion: 15.5
-FROM bci/bci-base:15.5
+FROM registry.suse.com/bci/bci-base:15.5
 
 RUN \\
     zypper -n install --no-recommends gcc emacs; \\
@@ -189,7 +189,7 @@ Copyright header
     <specification>SLE BCI Test Container Image</specification>
   </description>
   <preferences>
-    <type image="docker" derived_from="obsrepositories:/bci/bci-base#15.5">
+    <type image="docker" derived_from="obs://SUSE:Registry/standard/bci/bci-base#15.5">
       <containerconfig
           name="bci/test"
           tag="stable"
@@ -253,7 +253,7 @@ Copyright header
 #!BuildTag: bci/test:29-%RELEASE%
 #!BuildName: bci-test-29
 #!BuildVersion: 15.6.29
-FROM bci/bci-base:15.6
+FROM registry.suse.com/bci/bci-base:15.6
 
 RUN \\
     zypper -n install --no-recommends gcc emacs; \\
@@ -297,7 +297,7 @@ Copyright header
     <specification>SLE BCI Test Container Image</specification>
   </description>
   <preferences>
-    <type image="docker" derived_from="obsrepositories:/bci/bci-base#15.6">
+    <type image="docker" derived_from="obs://SUSE:Registry/standard/bci/bci-base#15.6">
       <containerconfig
           name="bci/test"
           tag="29"


### PR DESCRIPTION
This is needed so that we have the right oci annotations. Also fixup tests after last change.