### PR TITLE
Install gawk and other common devel packages in kiwi container

### DIFF
--- a/src/bci_build/package/kiwi.py
+++ b/src/bci_build/package/kiwi.py
@@ -51,7 +51,8 @@ KIWI_CONTAINERS = [
             "xorriso",
             "xz",
             *os_version.release_package_names,
-        ],
+        ]
+        + os_version.common_devel_packages,
         custom_end=f"{generate_package_version_check('python3-kiwi', kiwi_minor, ParseVersion.MINOR)}",
         build_recipe_type=BuildType.DOCKER,
         extra_labels={


### PR DESCRIPTION
The SL micro scripts are requiring it, and it kinda makes sense also for other usecases.