### PR TITLE
Move enumerations into a separate module

### DIFF
--- a/src/bci_build/container_attributes.py
+++ b/src/bci_build/container_attributes.py
@@ -1,0 +1,91 @@
+"""This package contains enumerations with constants like architectures or build
+types.
+
+"""
+
+import enum
+
+
+@enum.unique
+class Arch(enum.Enum):
+    """Architectures of packages on OBS"""
+
+    X86_64 = "x86_64"
+    AARCH64 = "aarch64"
+    PPC64LE = "ppc64le"
+    S390X = "s390x"
+    LOCAL = "local"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+@enum.unique
+class ReleaseStage(enum.Enum):
+    """Values for the ``release-stage`` label of a BCI"""
+
+    BETA = "beta"
+    RELEASED = "released"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+@enum.unique
+class ImageType(enum.Enum):
+    """Values of the ``image-type`` label of a BCI"""
+
+    LTSS = "ltss"
+    SLE_BCI = "sle-bci"
+    APPLICATION = "application"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+@enum.unique
+class BuildType(enum.Enum):
+    """Options for how the image is build, either as a kiwi build or from a
+    :file:`Dockerfile`.
+
+    """
+
+    DOCKER = "docker"
+    KIWI = "kiwi"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+@enum.unique
+class SupportLevel(enum.Enum):
+    """Potential values of the ``com.suse.supportlevel`` label."""
+
+    L2 = "l2"
+    L3 = "l3"
+    #: Additional Customer Contract
+    ACC = "acc"
+    UNSUPPORTED = "unsupported"
+    TECHPREVIEW = "techpreview"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+@enum.unique
+class PackageType(enum.Enum):
+    """Package types that are supported by kiwi, see
+    `<https://osinside.github.io/kiwi/concept_and_workflow/packages.html>`_ for
+    further details.
+
+    Note that these are only supported for kiwi builds.
+
+    """
+
+    DELETE = "delete"
+    UNINSTALL = "uninstall"
+    BOOTSTRAP = "bootstrap"
+    IMAGE = "image"
+
+    def __str__(self) -> str:
+        return self.value

--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -16,6 +16,12 @@ from typing import overload
 import jinja2
 from packaging import version
 
+from bci_build.container_attributes import Arch
+from bci_build.container_attributes import BuildType
+from bci_build.container_attributes import ImageType
+from bci_build.container_attributes import PackageType
+from bci_build.container_attributes import ReleaseStage
+from bci_build.container_attributes import SupportLevel
 from bci_build.containercrate import ContainerCrate
 from bci_build.os_version import ALL_OS_LTSS_VERSIONS
 from bci_build.os_version import RELEASED_OS_VERSIONS
@@ -38,91 +44,6 @@ DOCKERFILE_RUN: str = f"RUN {_BASH_SET};"
 #: Remove various log files. While it is possible to just ``rm -rf /var/log/*``,
 #: that would also remove some package owned directories (not %ghost)
 LOG_CLEAN: str = "rm -rf {/target,}/var/log/{alternatives.log,lastlog,tallylog,zypper.log,zypp/history,YaST2}"
-
-
-@enum.unique
-class Arch(enum.Enum):
-    """Architectures of packages on OBS"""
-
-    X86_64 = "x86_64"
-    AARCH64 = "aarch64"
-    PPC64LE = "ppc64le"
-    S390X = "s390x"
-    LOCAL = "local"
-
-    def __str__(self) -> str:
-        return self.value
-
-
-@enum.unique
-class ReleaseStage(enum.Enum):
-    """Values for the ``release-stage`` label of a BCI"""
-
-    BETA = "beta"
-    RELEASED = "released"
-
-    def __str__(self) -> str:
-        return self.value
-
-
-@enum.unique
-class ImageType(enum.Enum):
-    """Values of the ``image-type`` label of a BCI"""
-
-    LTSS = "ltss"
-    SLE_BCI = "sle-bci"
-    APPLICATION = "application"
-
-    def __str__(self) -> str:
-        return self.value
-
-
-@enum.unique
-class BuildType(enum.Enum):
-    """Options for how the image is build, either as a kiwi build or from a
-    :file:`Dockerfile`.
-
-    """
-
-    DOCKER = "docker"
-    KIWI = "kiwi"
-
-    def __str__(self) -> str:
-        return self.value
-
-
-@enum.unique
-class SupportLevel(enum.Enum):
-    """Potential values of the ``com.suse.supportlevel`` label."""
-
-    L2 = "l2"
-    L3 = "l3"
-    #: Additional Customer Contract
-    ACC = "acc"
-    UNSUPPORTED = "unsupported"
-    TECHPREVIEW = "techpreview"
-
-    def __str__(self) -> str:
-        return self.value
-
-
-@enum.unique
-class PackageType(enum.Enum):
-    """Package types that are supported by kiwi, see
-    `<https://osinside.github.io/kiwi/concept_and_workflow/packages.html>`_ for
-    further details.
-
-    Note that these are only supported for kiwi builds.
-
-    """
-
-    DELETE = "delete"
-    UNINSTALL = "uninstall"
-    BOOTSTRAP = "bootstrap"
-    IMAGE = "image"
-
-    def __str__(self) -> str:
-        return self.value
 
 
 @dataclass

--- a/src/bci_build/package/apache_tomcat.py
+++ b/src/bci_build/package/apache_tomcat.py
@@ -2,6 +2,7 @@
 
 import datetime
 
+from bci_build.container_attributes import PackageType
 from bci_build.containercrate import ContainerCrate
 from bci_build.os_version import CAN_BE_LATEST_OS_VERSION
 from bci_build.os_version import OsVersion
@@ -9,7 +10,6 @@ from bci_build.package import DOCKERFILE_RUN
 from bci_build.package import ApplicationStackContainer
 from bci_build.package import OsContainer
 from bci_build.package import Package
-from bci_build.package import PackageType
 from bci_build.package import Replacement
 from bci_build.package import _build_tag_prefix
 from bci_build.registry import publish_registry

--- a/src/bci_build/package/appcontainers.py
+++ b/src/bci_build/package/appcontainers.py
@@ -2,18 +2,18 @@
 
 from pathlib import Path
 
+from bci_build.container_attributes import BuildType
+from bci_build.container_attributes import PackageType
+from bci_build.container_attributes import SupportLevel
 from bci_build.os_version import ALL_NONBASE_OS_VERSIONS
 from bci_build.os_version import CAN_BE_LATEST_OS_VERSION
 from bci_build.os_version import OsVersion
 from bci_build.package import DOCKERFILE_RUN
 from bci_build.package import ApplicationStackContainer
-from bci_build.package import BuildType
 from bci_build.package import OsContainer
 from bci_build.package import Package
-from bci_build.package import PackageType
 from bci_build.package import ParseVersion
 from bci_build.package import Replacement
-from bci_build.package import SupportLevel
 from bci_build.package import _build_tag_prefix
 from bci_build.package.helpers import generate_from_image_tag
 from bci_build.package.helpers import generate_package_version_check

--- a/src/bci_build/package/base.py
+++ b/src/bci_build/package/base.py
@@ -5,13 +5,13 @@ from pathlib import Path
 
 from jinja2 import Template
 
+from bci_build.container_attributes import Arch
+from bci_build.container_attributes import BuildType
+from bci_build.container_attributes import PackageType
+from bci_build.container_attributes import SupportLevel
 from bci_build.os_version import OsVersion
-from bci_build.package import Arch
-from bci_build.package import BuildType
 from bci_build.package import OsContainer
 from bci_build.package import Package
-from bci_build.package import PackageType
-from bci_build.package import SupportLevel
 
 
 def _get_base_config_sh_script(os_version: OsVersion) -> str:

--- a/src/bci_build/package/basecontainers.py
+++ b/src/bci_build/package/basecontainers.py
@@ -5,6 +5,10 @@ import os
 import textwrap
 from pathlib import Path
 
+from bci_build.container_attributes import Arch
+from bci_build.container_attributes import BuildType
+from bci_build.container_attributes import PackageType
+from bci_build.container_attributes import SupportLevel
 from bci_build.os_version import ALL_BASE_OS_VERSIONS
 from bci_build.os_version import ALL_OS_LTSS_VERSIONS
 from bci_build.os_version import ALL_OS_VERSIONS
@@ -12,12 +16,8 @@ from bci_build.os_version import CAN_BE_LATEST_OS_VERSION
 from bci_build.os_version import _SUPPORTED_UNTIL_SLE
 from bci_build.os_version import OsVersion
 from bci_build.package import DOCKERFILE_RUN
-from bci_build.package import Arch
-from bci_build.package import BuildType
 from bci_build.package import OsContainer
 from bci_build.package import Package
-from bci_build.package import PackageType
-from bci_build.package import SupportLevel
 from bci_build.package import _build_tag_prefix
 from bci_build.package import generate_disk_size_constraints
 

--- a/src/bci_build/package/gcc.py
+++ b/src/bci_build/package/gcc.py
@@ -3,13 +3,13 @@
 import datetime
 from typing import Literal
 
+from bci_build.container_attributes import SupportLevel
 from bci_build.os_version import CAN_BE_LATEST_OS_VERSION
 from bci_build.os_version import OsVersion
 from bci_build.package import DOCKERFILE_RUN
 from bci_build.package import DevelopmentContainer
 from bci_build.package import ParseVersion
 from bci_build.package import Replacement
-from bci_build.package import SupportLevel
 from bci_build.package import generate_disk_size_constraints
 
 _GCC_VERSIONS = Literal[7, 12, 13, 14]

--- a/src/bci_build/package/golang.py
+++ b/src/bci_build/package/golang.py
@@ -4,13 +4,13 @@ import textwrap
 from itertools import product
 from typing import Literal
 
+from bci_build.container_attributes import SupportLevel
 from bci_build.os_version import CAN_BE_LATEST_OS_VERSION
 from bci_build.os_version import OsVersion
 from bci_build.package import DOCKERFILE_RUN
 from bci_build.package import LOG_CLEAN
 from bci_build.package import DevelopmentContainer
 from bci_build.package import Replacement
-from bci_build.package import SupportLevel
 from bci_build.package import generate_disk_size_constraints
 
 _GO_VER_T = Literal["1.20", "1.21", "1.22", "1.23"]

--- a/src/bci_build/package/kiwi.py
+++ b/src/bci_build/package/kiwi.py
@@ -1,9 +1,9 @@
 """KIWI Appliances Builder SDK container for easy appliance building on SLE Micro."""
 
+from bci_build.container_attributes import BuildType
 from bci_build.os_version import ALL_NONBASE_OS_VERSIONS
 from bci_build.os_version import CAN_BE_LATEST_OS_VERSION
 from bci_build.os_version import OsVersion
-from bci_build.package import BuildType
 from bci_build.package import DevelopmentContainer
 from bci_build.package import ParseVersion
 from bci_build.package import generate_disk_size_constraints

--- a/src/bci_build/package/mariadb.py
+++ b/src/bci_build/package/mariadb.py
@@ -3,15 +3,15 @@
 import re
 from pathlib import Path
 
+from bci_build.container_attributes import BuildType
+from bci_build.container_attributes import SupportLevel
 from bci_build.os_version import ALL_NONBASE_OS_VERSIONS
 from bci_build.os_version import CAN_BE_LATEST_OS_VERSION
 from bci_build.os_version import OsVersion
 from bci_build.package import DOCKERFILE_RUN
 from bci_build.package import ApplicationStackContainer
-from bci_build.package import BuildType
 from bci_build.package import ParseVersion
 from bci_build.package import Replacement
-from bci_build.package import SupportLevel
 from bci_build.package import generate_disk_size_constraints
 from bci_build.package.helpers import generate_package_version_check
 from bci_build.package.versions import get_pkg_version

--- a/src/bci_build/package/node.py
+++ b/src/bci_build/package/node.py
@@ -3,12 +3,12 @@
 import datetime
 from typing import Literal
 
+from bci_build.container_attributes import SupportLevel
 from bci_build.os_version import CAN_BE_LATEST_OS_VERSION
 from bci_build.os_version import _SUPPORTED_UNTIL_SLE
 from bci_build.os_version import OsVersion
 from bci_build.package import DevelopmentContainer
 from bci_build.package import Replacement
-from bci_build.package import SupportLevel
 
 _NODE_VERSIONS = Literal[16, 18, 20, 21, 22, 23, 24]
 

--- a/src/bci_build/package/openjdk.py
+++ b/src/bci_build/package/openjdk.py
@@ -4,12 +4,12 @@ import os
 from itertools import product
 from typing import Literal
 
+from bci_build.container_attributes import Arch
+from bci_build.container_attributes import SupportLevel
 from bci_build.os_version import OsVersion
 from bci_build.package import DOCKERFILE_RUN
-from bci_build.package import Arch
 from bci_build.package import DevelopmentContainer
 from bci_build.package import Replacement
-from bci_build.package import SupportLevel
 from bci_build.package import _build_tag_prefix
 from bci_build.package import generate_disk_size_constraints
 

--- a/src/bci_build/package/php.py
+++ b/src/bci_build/package/php.py
@@ -2,13 +2,13 @@ import enum
 from itertools import product
 from typing import Literal
 
+from bci_build.container_attributes import SupportLevel
 from bci_build.os_version import CAN_BE_LATEST_OS_VERSION
 from bci_build.os_version import OsVersion
 from bci_build.package import DOCKERFILE_RUN
 from bci_build.package import _BASH_SET
 from bci_build.package import DevelopmentContainer
 from bci_build.package import Replacement
-from bci_build.package import SupportLevel
 
 
 @enum.unique

--- a/src/bci_build/package/postfix.py
+++ b/src/bci_build/package/postfix.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+from bci_build.container_attributes import SupportLevel
 from bci_build.os_version import ALL_NONBASE_OS_VERSIONS
 from bci_build.os_version import CAN_BE_LATEST_OS_VERSION
 from bci_build.os_version import OsVersion
@@ -9,7 +10,6 @@ from bci_build.package import DOCKERFILE_RUN
 from bci_build.package import ApplicationStackContainer
 from bci_build.package import ParseVersion
 from bci_build.package import Replacement
-from bci_build.package import SupportLevel
 from bci_build.package.helpers import generate_from_image_tag
 from bci_build.registry import ApplicationCollectionRegistry
 

--- a/src/bci_build/package/postgres.py
+++ b/src/bci_build/package/postgres.py
@@ -2,12 +2,12 @@
 
 from pathlib import Path
 
+from bci_build.container_attributes import SupportLevel
 from bci_build.os_version import OsVersion
 from bci_build.package import DOCKERFILE_RUN
 from bci_build.package import ApplicationStackContainer
 from bci_build.package import ParseVersion
 from bci_build.package import Replacement
-from bci_build.package import SupportLevel
 from bci_build.package import generate_disk_size_constraints
 
 _POSTGRES_ENTRYPOINT = (

--- a/src/bci_build/package/python.py
+++ b/src/bci_build/package/python.py
@@ -4,12 +4,12 @@ import datetime
 from dataclasses import dataclass
 from typing import Literal
 
+from bci_build.container_attributes import SupportLevel
 from bci_build.os_version import CAN_BE_LATEST_OS_VERSION
 from bci_build.os_version import _SUPPORTED_UNTIL_SLE
 from bci_build.os_version import OsVersion
 from bci_build.package import DevelopmentContainer
 from bci_build.package import Replacement
-from bci_build.package import SupportLevel
 from bci_build.registry import publish_registry
 
 _PYTHON_VERSIONS = Literal["3.6", "3.9", "3.10", "3.11", "3.12"]

--- a/src/bci_build/package/rmt.py
+++ b/src/bci_build/package/rmt.py
@@ -2,11 +2,11 @@
 
 from pathlib import Path
 
+from bci_build.container_attributes import BuildType
 from bci_build.os_version import ALL_NONBASE_OS_VERSIONS
 from bci_build.os_version import CAN_BE_LATEST_OS_VERSION
 from bci_build.package import DOCKERFILE_RUN
 from bci_build.package import ApplicationStackContainer
-from bci_build.package import BuildType
 from bci_build.package import ParseVersion
 from bci_build.package import Replacement
 

--- a/src/bci_build/package/ruby.py
+++ b/src/bci_build/package/ruby.py
@@ -2,12 +2,12 @@
 
 from typing import Literal
 
+from bci_build.container_attributes import SupportLevel
 from bci_build.os_version import CAN_BE_LATEST_OS_VERSION
 from bci_build.os_version import OsVersion
 from bci_build.package import DevelopmentContainer
 from bci_build.package import ParseVersion
 from bci_build.package import Replacement
-from bci_build.package import SupportLevel
 from bci_build.package import generate_disk_size_constraints
 
 

--- a/src/bci_build/package/rust.py
+++ b/src/bci_build/package/rust.py
@@ -3,11 +3,11 @@
 import datetime
 from itertools import product
 
+from bci_build.container_attributes import SupportLevel
 from bci_build.os_version import ALL_NONBASE_OS_VERSIONS
 from bci_build.os_version import CAN_BE_LATEST_OS_VERSION
 from bci_build.package import DevelopmentContainer
 from bci_build.package import Replacement
-from bci_build.package import SupportLevel
 from bci_build.package import generate_disk_size_constraints
 
 _RUST_GCC_PATH = "/usr/local/bin/gcc"

--- a/src/bci_build/package/spack.py
+++ b/src/bci_build/package/spack.py
@@ -1,13 +1,13 @@
 """HPC container for Spack package manager."""
 
+from bci_build.container_attributes import Arch
+from bci_build.container_attributes import SupportLevel
 from bci_build.os_version import CAN_BE_LATEST_OS_VERSION
 from bci_build.os_version import _SUPPORTED_UNTIL_SLE
 from bci_build.os_version import OsVersion
 from bci_build.package import DOCKERFILE_RUN
-from bci_build.package import Arch
 from bci_build.package import DevelopmentContainer
 from bci_build.package import ParseVersion
-from bci_build.package import SupportLevel
 from bci_build.package import generate_disk_size_constraints
 from bci_build.package.helpers import generate_package_version_check
 from bci_build.package.versions import format_version

--- a/src/staging/build_result.py
+++ b/src/staging/build_result.py
@@ -3,7 +3,7 @@ import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from dataclasses import field
 
-from bci_build.package import Arch
+from bci_build.container_attributes import Arch
 from staging.util import get_obs_project_url
 
 

--- a/tests/test_build_recipe.py
+++ b/tests/test_build_recipe.py
@@ -2,14 +2,14 @@ from datetime import date
 
 import pytest
 
+from bci_build.container_attributes import Arch
+from bci_build.container_attributes import BuildType
+from bci_build.container_attributes import PackageType
+from bci_build.container_attributes import SupportLevel
 from bci_build.os_version import OsVersion
-from bci_build.package import Arch
-from bci_build.package import BuildType
 from bci_build.package import DevelopmentContainer
 from bci_build.package import OsContainer
 from bci_build.package import Package
-from bci_build.package import PackageType
-from bci_build.package import SupportLevel
 from bci_build.templates import DOCKERFILE_TEMPLATE
 from bci_build.templates import KIWI_TEMPLATE
 

--- a/tests/test_crate.py
+++ b/tests/test_crate.py
@@ -1,6 +1,6 @@
+from bci_build.container_attributes import BuildType
 from bci_build.containercrate import ContainerCrate
 from bci_build.os_version import OsVersion
-from bci_build.package import BuildType
 from bci_build.package import DevelopmentContainer
 
 _BASE_KWARGS = {

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,6 +1,6 @@
+from bci_build.container_attributes import BuildType
 from bci_build.containercrate import ContainerCrate
 from bci_build.os_version import OsVersion
-from bci_build.package import BuildType
 from bci_build.package import DevelopmentContainer
 from bci_build.package import ParseVersion
 from bci_build.package import Replacement


### PR DESCRIPTION
Having the enums in a separate module allows us to import it in other modules without having import cycles, split out of https://github.com/SUSE/BCI-dockerfile-generator/pull/1815