### PR TITLE
Use VERSION-RELEASE for new/future OsContainers

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -1323,6 +1323,10 @@ class OsContainer(BaseContainerImage):
 
     @property
     def oci_version(self) -> str:
+        # use the more standard VERSION-RELEASE scheme we use everywhere else for new containers
+        if self.os_version not in (OsVersion.SP4, OsVersion.SP5, OsVersion.SP6):
+            return "%OS_VERSION_ID_SP%-%RELEASE%"
+
         return "%OS_VERSION_ID_SP%.%RELEASE%"
 
     @property

--- a/tests/test_build_recipe.py
+++ b/tests/test_build_recipe.py
@@ -522,7 +522,7 @@ def test_build_recipe_templates(
 <!--
 Copyright header
 -->
-<!-- OBS-AddTag: opensuse/bci/bci-test:%OS_VERSION_ID_SP% opensuse/bci/bci-test:%OS_VERSION_ID_SP%.%RELEASE% opensuse/bci/bci-test:latest -->
+<!-- OBS-AddTag: opensuse/bci/bci-test:%OS_VERSION_ID_SP% opensuse/bci/bci-test:%OS_VERSION_ID_SP%-%RELEASE% opensuse/bci/bci-test:latest -->
 <!-- OBS-Imagerepo: obsrepositories:/ -->
 
 <image schemaversion="7.4" name="test-image" xmlns:suse_label_helper="com.suse.label_helper">
@@ -536,19 +536,19 @@ Copyright header
       <containerconfig
           name="opensuse/bci/bci-test"
           tag="%OS_VERSION_ID_SP%"
-          additionaltags="%OS_VERSION_ID_SP%.%RELEASE%,latest">
+          additionaltags="%OS_VERSION_ID_SP%-%RELEASE%,latest">
         <labels>
           <suse_label_helper:add_prefix prefix="org.opensuse.bci.test">
             <label name="org.opencontainers.image.authors" value="openSUSE (https://www.opensuse.org/)"/>
             <label name="org.opencontainers.image.title" value="openSUSE Tumbleweed BCI Test"/>
             <label name="org.opencontainers.image.description" value="A test environment for containers."/>
-            <label name="org.opencontainers.image.version" value="%OS_VERSION_ID_SP%.%RELEASE%"/>
+            <label name="org.opencontainers.image.version" value="%OS_VERSION_ID_SP%-%RELEASE%"/>
             <label name="org.opencontainers.image.created" value="%BUILDTIME%"/>
             <label name="org.opencontainers.image.vendor" value="openSUSE Project"/>
             <label name="org.opencontainers.image.source" value="%SOURCEURL%"/>
             <label name="org.opencontainers.image.url" value="https://www.opensuse.org"/>
-            <label name="org.opencontainers.image.ref.name" value="%OS_VERSION_ID_SP%.%RELEASE%"/>
-            <label name="org.opensuse.reference" value="registry.opensuse.org/opensuse/bci/bci-test:%OS_VERSION_ID_SP%.%RELEASE%"/>
+            <label name="org.opencontainers.image.ref.name" value="%OS_VERSION_ID_SP%-%RELEASE%"/>
+            <label name="org.opensuse.reference" value="registry.opensuse.org/opensuse/bci/bci-test:%OS_VERSION_ID_SP%-%RELEASE%"/>
             <label name="org.openbuildservice.disturl" value="%DISTURL%"/>
             <label name="org.opensuse.release-stage" value="released"/>
             <label name="org.opensuse.lifecycle-url" value="https://en.opensuse.org/Lifetime#openSUSE_BCI"/>


### PR DESCRIPTION
As decided, we're aligning the tagging scheme between OsContainers and Development Containers. To avoid friction with existing users and pipelines, we do this change only for future releases.