### PR TITLE
OpenJDK 22 reached end of life

### DIFF
--- a/src/bci_build/package/openjdk.py
+++ b/src/bci_build/package/openjdk.py
@@ -17,7 +17,7 @@ from bci_build.package import generate_disk_size_constraints
 def _get_openjdk_kwargs(
     os_version: OsVersion,
     devel: bool,
-    java_version: Literal[11, 13, 15, 17, 20, 21, 22],
+    java_version: Literal[11, 13, 15, 17, 20, 21, 23],
 ):
     JAVA_HOME = f"/usr/lib64/jvm/java-{java_version}-openjdk-{java_version}"
     JAVA_ENV = {
@@ -28,7 +28,7 @@ def _get_openjdk_kwargs(
     }
 
     is_latest = (java_version == 21 and os_version.is_sle15) or (
-        java_version == 22 and os_version.is_tumbleweed
+        java_version == 23 and os_version.is_tumbleweed
     )
 
     common = {
@@ -108,7 +108,7 @@ OPENJDK_CONTAINERS = (
     ]
     + [
         DevelopmentContainer(
-            **_get_openjdk_kwargs(os_version=os_version, devel=devel, java_version=22),
+            **_get_openjdk_kwargs(os_version=os_version, devel=devel, java_version=23),
             support_level=SupportLevel.L3,
         )
         for os_version, devel in product((OsVersion.TUMBLEWEED,), (True, False))


### PR DESCRIPTION
OpenJDK 22 is being deleted from Factory: https://build.opensuse.org/requests/1208236