### PR TITLE
Switch kiwi tag_version to minor version

### DIFF
--- a/src/bci_build/package/kiwi.py
+++ b/src/bci_build/package/kiwi.py
@@ -23,10 +23,10 @@ KIWI_CONTAINERS = [
         version=format_version(
             kiwi_ver := get_pkg_version("python-kiwi", os_version), ParseVersion.PATCH
         ),
-        tag_version=format_version(kiwi_ver, ParseVersion.MAJOR),
+        tag_version=(kiwi_minor := format_version(kiwi_ver, ParseVersion.MINOR)),
         version_in_uid=False,
         additional_versions=[
-            (kiwi_minor := format_version(kiwi_ver, ParseVersion.MINOR)),
+            format_version(kiwi_ver, ParseVersion.MAJOR),
         ],
         license="GPL-3.0-or-later",
         package_list=[


### PR DESCRIPTION
This is how it was before, and since we already released containers that way it is perceived a downgrade otherwise.