### PR TITLE
Add python 3.11 for SP7 as well

### DIFF
--- a/src/bci_build/package/python.py
+++ b/src/bci_build/package/python.py
@@ -133,7 +133,7 @@ PYTHON_3_11_CONTAINERS = (
         **_get_python_kwargs("3.11", os_version),
         package_name="python-3.11-image",
     )
-    for os_version in (OsVersion.SP6,)
+    for os_version in (OsVersion.SP6, OsVersion.SP7)
 )
 
 PYTHON_3_12_CONTAINERS = [


### PR DESCRIPTION
It currently is scheduled to go out of maintenance in the middle of SP7, but it will go longer than SP6 general support, so we do have to move to sp7 eventually.