### PR TITLE
Provide a gcc 14 container (jsc#PED-11081)

### DIFF
--- a/src/bci_build/package/gcc.py
+++ b/src/bci_build/package/gcc.py
@@ -19,18 +19,17 @@ _GCC_VERSIONS = Literal[7, 12, 13, 14]
 # https://gcc.gnu.org/releases.html
 _GCC_SLCC_SUPPORTED_UNTIL: dict[_GCC_VERSIONS, datetime.date | None] = {
     13: datetime.date(2025, 7, 31),
-    14: None,
+    14: datetime.date(2026, 7, 31),
 }
 
 
 def _is_latest_gcc(os_version: OsVersion, gcc_version: _GCC_VERSIONS) -> bool:
     if os_version == OsVersion.TUMBLEWEED and gcc_version == 14:
         return True
-    if os_version.is_sle15 and gcc_version == 13:
+    if os_version.is_sle15 and gcc_version == 14:
         return True
-    # if os_version in (OsVersion.SLCC_DEVELOPMENT, OsVersion.SLCC_PRODUCTION):
-    #     assert gcc_version == 13
-    #     return True
+    if os_version.is_slfo and gcc_version == 14:
+        return True
     return False
 
 
@@ -39,9 +38,8 @@ def _is_main_gcc(os_version: OsVersion, gcc_version: _GCC_VERSIONS) -> bool:
         return True
     if os_version.is_sle15 and gcc_version == 7:
         return True
-    # if os_version in (OsVersion.SLCC_DEVELOPMENT, OsVersion.SLCC_PRODUCTION):
-    #     assert gcc_version == 13
-    #     return True
+    if os_version.is_slfo and gcc_version == 14:
+        return True
     return False
 
 
@@ -52,14 +50,8 @@ GCC_CONTAINERS = [
         os_version=os_version,
         version="%%gcc_minor_version%%",
         tag_version=gcc_version,
-        support_level=(
-            SupportLevel.L3 if not os_version.is_sle15 else SupportLevel.TECHPREVIEW
-        ),
-        supported_until=(
-            _GCC_SLCC_SUPPORTED_UNTIL.get(gcc_version)
-            if not os_version.is_sle15
-            else None
-        ),
+        support_level=SupportLevel.L3,
+        supported_until=_GCC_SLCC_SUPPORTED_UNTIL.get(gcc_version),
         package_list=(
             [
                 (gcc_pkg := f"gcc{gcc_version}"),
@@ -96,12 +88,9 @@ GCC_CONTAINERS = [
         ),
     )
     for (gcc_version, os_version) in (
-        (7, OsVersion.SP6),
-        (13, OsVersion.SP6),
-        (7, OsVersion.SP7),
-        (13, OsVersion.SP7),
-        # (13, OsVersion.SLCC_DEVELOPMENT),
-        # (13, OsVersion.SLCC_PRODUCTION),
+        (14, OsVersion.SP6),
+        (14, OsVersion.SP7),
+        (14, OsVersion.SLE16_0),
         (12, OsVersion.TUMBLEWEED),
         (13, OsVersion.TUMBLEWEED),
         (14, OsVersion.TUMBLEWEED),


### PR DESCRIPTION
Drop Gcc 7 and 13 as we can only provide the latest version.