### PR TITLE
Set the buildrelease counter on the main dockerfile

### DIFF
--- a/src/bci_build/containercrate.py
+++ b/src/bci_build/containercrate.py
@@ -30,9 +30,13 @@ class ContainerCrate:
             )
         )
 
-    def default_dockerfile(self) -> str:
+    def default_dockerfile(self, container) -> str:
+        buildrelease: str = ""
+        if container.build_release:
+            buildrelease = f"\n#!BuildVersion: workaround-for-an-obs-bug\n#!BuildRelease: {container.build_release}"
         """Return a default Dockerfile to disable build on default flavor."""
-        return """#!ExclusiveArch: do-not-build
+        return f"""#!ExclusiveArch: do-not-build
+#!ForceMultiVersion{buildrelease}
 
 # For this container we only build the Dockerfile.$flavor builds.
 """

--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -1099,7 +1099,7 @@ exit 0
 
         if self.build_flavor:
             dfile = "Dockerfile"
-            tasks.append(write_file_to_dest(dfile, self.crate.default_dockerfile()))
+            tasks.append(write_file_to_dest(dfile, self.crate.default_dockerfile(self)))
             files.append(dfile)
 
             mname = "_multibuild"


### PR DESCRIPTION
The buildrelease on flavor builds are ignored and copied from the main one.