### PR TITLE
Overwrite the incorrect author from the base container in appcol

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -348,8 +348,8 @@ class BaseContainerImage(abc.ABC):
             # Limit to aarch64 and x86_64
             if not self.exclusive_arch:
                 self.exclusive_arch = [Arch.AARCH64, Arch.X86_64]
-            # Disable maintainer listing
-            self.maintainer = None
+            # Override maintainer listing from base container by setting an empty value
+            self.maintainer = ""
 
         # limit to tech preview for beta releases
         if (

--- a/src/bci_build/templates.py
+++ b/src/bci_build/templates.py
@@ -57,7 +57,7 @@ COPY --from=target / /target
 COPY --from=builder /target /{% endif %}
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix={{ image.labelprefix }}
-{%- if image.maintainer %}
+{%- if image.maintainer != None %}
 LABEL org.opencontainers.image.authors="{{ image.maintainer }}"
 {%- endif %}
 LABEL org.opencontainers.image.title="{{ image.title }}"

--- a/tests/test_build_recipe.py
+++ b/tests/test_build_recipe.py
@@ -641,6 +641,7 @@ FROM registry.suse.com/bci/bci-micro:15.6
 COPY --from=builder /target /
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=com.suse.application.test
+LABEL org.opencontainers.image.authors=""
 LABEL org.opencontainers.image.title="Test"
 LABEL org.opencontainers.image.description="Test container based on the SLE Base Container Image."
 LABEL org.opencontainers.image.version="%%emacs_version%%"


### PR DESCRIPTION
Appcollection wants no maintainer, which is however inherited from the base container.