### PR TITLE
Provide gfortran also in the gcc container

### DIFF
--- a/src/bci_build/package/gcc.py
+++ b/src/bci_build/package/gcc.py
@@ -56,9 +56,14 @@ GCC_CONTAINERS = [
             [
                 (gcc_pkg := f"gcc{gcc_version}"),
                 (gpp := f"{gcc_pkg}-c++"),
+                (gfortran := f"{gcc_pkg}-fortran"),
                 "make",
             ]
-            + (["gcc", "gcc-c++"] if _is_main_gcc(os_version, gcc_version) else [])
+            + (
+                ["gcc", "gcc-c++", "gcc-fortran"]
+                if _is_main_gcc(os_version, gcc_version)
+                else []
+            )
             + os_version.common_devel_packages
             + os_version.lifecycle_data_pkg
         ),
@@ -79,7 +84,7 @@ GCC_CONTAINERS = [
         custom_end=(
             rf"""# symlink all versioned gcc & g++ binaries to unversioned
 # ones in /usr/local/bin so that plain gcc works
-{DOCKERFILE_RUN} for gcc_bin in $(rpm -ql {gcc_pkg} {gpp} |grep ^/usr/bin/ ); do \
+{DOCKERFILE_RUN} for gcc_bin in $(rpm -ql {gcc_pkg} {gpp} {gfortran} |grep ^/usr/bin/ ); do \
         ln -sf $gcc_bin $(echo "$gcc_bin" | sed -e 's|/usr/bin/|/usr/local/bin/|' -e 's|-{gcc_version}$||'); \
     done
 """

--- a/src/bci_build/package/gcc/README.md.j2
+++ b/src/bci_build/package/gcc/README.md.j2
@@ -59,10 +59,9 @@ using `zypper`. This includes the following:
 ### Available compiler frontends
 
 The GNU Compiler Collections supports a wide range of frontends. The container
-image ships the C and C++ frontends available as `gcc` and `g++`
+image ships the C,  C++  and fortran frontends available as `gcc`, `g++` and `gfortran`
 respectively. The following additional frontends can be installed from the
 repository:
-- `gcc{{ image.tag_version }}-fortran` for Fortran support
 {% if (image.tag_version == 7) or (image.os_version.is_tumbleweed) %}- `gcc{{ image.tag_version }}-ada` for the Ada frontend (GNAT)
 {% endif %}{% if image.os_version.is_tumbleweed %}- `gcc{{ image.tag_version }}-go` for the Go frontend
 - `gcc{{ image.tag_version }}-objc` and `gcc{{ image.tag_version }}-obj-c++` for the Objective C and Objective C++


### PR DESCRIPTION
This is equally supported to c/c++, no reason to exclude it. this means we can also test it in BCI-tests via "gfortran" then.