### PR TITLE
Remove -%RELEASE% suffix for tag versions

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -1277,11 +1277,8 @@ class DevelopmentContainer(BaseContainerImage):
     @property
     def build_tags(self) -> list[str]:
         tags = []
-
         for name in [self.name] + self.additional_names:
             ver_labels: list[str] = [self._version_variant]
-            if self._version_variant != self._tag_variant:
-                ver_labels.append(self._tag_variant)
             if self.stability_tag:
                 ver_labels = [self.stability_tag] + ver_labels
             for ver_label in ver_labels:
@@ -1289,7 +1286,10 @@ class DevelopmentContainer(BaseContainerImage):
                     f"{self.registry_prefix}/{name}:{ver_label}-{self._release_suffix}"
                 ]
                 tags += [f"{self.registry_prefix}/{name}:{ver_label}"]
-            for ver_label in self.additional_versions:
+            additional_ver_labels: list[str] = self.additional_versions
+            if self._version_variant != self._tag_variant:
+                additional_ver_labels = [self._tag_variant] + additional_ver_labels
+            for ver_label in additional_ver_labels:
                 tags += [f"{self.registry_prefix}/{name}:{ver_label}"]
 
             if self.is_latest:

--- a/src/bci_build/package/python.py
+++ b/src/bci_build/package/python.py
@@ -62,7 +62,6 @@ def _get_python_kwargs(py3_ver: _PYTHON_VERSIONS, os_version: OsVersion):
         "pretty_name": f"Python {py3_ver} development",
         "version": py3_ver_replacement,
         "tag_version": py3_ver,
-        "additional_versions": ["3"],
         "env": {
             "PYTHON_VERSION": py3_ver_replacement,
             "PATH": "$PATH:/root/.local/bin",
@@ -105,6 +104,7 @@ PYTHON_3_6_CONTAINERS = (
     PythonDevelopmentContainer(
         **_get_python_kwargs("3.6", os_version),
         package_name="python-3.6-image",
+        additional_versions=["3"],
     )
     for os_version in (OsVersion.SP6,)
 )
@@ -124,6 +124,7 @@ PYTHON_TW_CONTAINERS = (
         **_get_python_kwargs(pyver, OsVersion.TUMBLEWEED),
         is_latest=pyver == _PYTHON_TW_VERSIONS[-1],
         package_name=f"python-{pyver}-image",
+        additional_versions=["3"],
     )
     for pyver in _PYTHON_TW_VERSIONS
 )
@@ -132,6 +133,7 @@ PYTHON_3_11_CONTAINERS = (
     PythonDevelopmentContainer(
         **_get_python_kwargs("3.11", os_version),
         package_name="python-3.11-image",
+        additional_versions=["3"],
     )
     for os_version in (OsVersion.SP6, OsVersion.SP7)
 )
@@ -141,6 +143,7 @@ PYTHON_3_12_CONTAINERS = [
         **_get_python_kwargs("3.12", os_version),
         package_name="python-3.12-image",
         is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
+        additional_versions=["3"],
     )
     for os_version in (OsVersion.SP6, OsVersion.SP7)
 ]

--- a/tests/test_build_recipe.py
+++ b/tests/test_build_recipe.py
@@ -623,7 +623,6 @@ def test_os_build_recipe_templates(kiwi_xml: str, image: OsContainer) -> None:
 #!ExclusiveArch: aarch64 x86_64
 #!BuildTag: containers/test:%%emacs_version%%-%RELEASE%
 #!BuildTag: containers/test:%%emacs_version%%
-#!BuildTag: containers/test:42-%RELEASE%
 #!BuildTag: containers/test:42
 #!ForceMultiVersion
 #!BuildName: containers-test-42


### PR DESCRIPTION
If we already have a tag with a -%RELEASE% suffix, we don't need to create anothher one for the tag_version, which messes up the registry.suse.com rendering and is apparently an issue for AppCollection as well.