### PR TITLE
Map mariadb's 11.5 to 11.4 for now

### DIFF
--- a/src/bci_build/package/mariadb/10.11/entrypoint.sh
+++ b/src/bci_build/package/mariadb/10.11/entrypoint.sh
@@ -121,6 +121,7 @@ mysql_get_config() {
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF \
 		--expire-logs-days=0 \
+		--skip-slave-start \
 		--loose-innodb_buffer_pool_load_at_startup=0 \
 		&
 	declare -g MARIADB_PID
@@ -222,7 +223,7 @@ docker_create_db_directories() {
 }
 
 _mariadb_version() {
-	echo -n "10.11.9-MariaDB"
+	echo -n "10.11.10-MariaDB"
 }
 
 # initializes the database directory
@@ -458,7 +459,6 @@ docker_setup_db() {
 	# To create replica user
 	local createReplicaUser=
 	local changeMasterTo=
-	local startReplica=
 	if  [ -n "$MARIADB_REPLICATION_USER" ] ; then
 		if [ -z "$MARIADB_MASTER_HOST" ]; then
 			# on master
@@ -471,7 +471,6 @@ docker_setup_db() {
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
 			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
-			startReplica="START REPLICA;"
 		fi
 	fi
 
@@ -502,7 +501,6 @@ docker_setup_db() {
 		${userGrants}
 
 		${changeMasterTo}
-		${startReplica}
 	EOSQL
 }
 
@@ -598,8 +596,7 @@ docker_mariadb_upgrade() {
 	fi
 	mysql_note "Starting temporary server"
 	docker_temp_server_start "$@" --skip-grant-tables \
-		--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-		--skip-slave-start
+		--loose-innodb_buffer_pool_dump_at_shutdown=0
 	mysql_note "Temporary server started."
 
 	docker_mariadb_backup_system
@@ -624,8 +621,7 @@ EOSQL
 			# need a restart as FLUSH PRIVILEGES isn't reversable
 			mysql_note "Restarting temporary server for upgrade"
 			docker_temp_server_start "$@" --skip-grant-tables \
-				--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-				--skip-slave-start
+				--loose-innodb_buffer_pool_dump_at_shutdown=0
 		else
 			return 0
 		fi

--- a/src/bci_build/package/mariadb/10.11/healthcheck.sh
+++ b/src/bci_build/package/mariadb/10.11/healthcheck.sh
@@ -361,6 +361,11 @@ while [ $# -gt 0 ]; do
 			fi
 			nodefaults=
 			;;
+		--no-connect)
+			# used for /docker-entrypoint-initdb.d scripts
+			# where you definately don't want a connection test
+			connect_s=0
+			;;
 		--*)
 			test=${1#--}
 			;;

--- a/src/bci_build/package/mariadb/10.6/entrypoint.sh
+++ b/src/bci_build/package/mariadb/10.6/entrypoint.sh
@@ -121,6 +121,7 @@ mysql_get_config() {
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF \
 		--expire-logs-days=0 \
+		--skip-slave-start \
 		--loose-innodb_buffer_pool_load_at_startup=0 \
 		&
 	declare -g MARIADB_PID
@@ -214,7 +215,7 @@ docker_create_db_directories() {
 }
 
 _mariadb_version() {
-	echo -n "10.6.19-MariaDB"
+	echo -n "10.6.20-MariaDB"
 }
 
 # initializes the database directory
@@ -450,7 +451,6 @@ docker_setup_db() {
 	# To create replica user
 	local createReplicaUser=
 	local changeMasterTo=
-	local startReplica=
 	if  [ -n "$MARIADB_REPLICATION_USER" ] ; then
 		if [ -z "$MARIADB_MASTER_HOST" ]; then
 			# on master
@@ -463,7 +463,6 @@ docker_setup_db() {
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
 			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
-			startReplica="START REPLICA;"
 		fi
 	fi
 
@@ -494,7 +493,6 @@ docker_setup_db() {
 		${userGrants}
 
 		${changeMasterTo}
-		${startReplica}
 	EOSQL
 }
 
@@ -590,8 +588,7 @@ docker_mariadb_upgrade() {
 	fi
 	mysql_note "Starting temporary server"
 	docker_temp_server_start "$@" --skip-grant-tables \
-		--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-		--skip-slave-start
+		--loose-innodb_buffer_pool_dump_at_shutdown=0
 	mysql_note "Temporary server started."
 
 	docker_mariadb_backup_system
@@ -616,8 +613,7 @@ EOSQL
 			# need a restart as FLUSH PRIVILEGES isn't reversable
 			mysql_note "Restarting temporary server for upgrade"
 			docker_temp_server_start "$@" --skip-grant-tables \
-				--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-				--skip-slave-start
+				--loose-innodb_buffer_pool_dump_at_shutdown=0
 		else
 			return 0
 		fi

--- a/src/bci_build/package/mariadb/10.6/healthcheck.sh
+++ b/src/bci_build/package/mariadb/10.6/healthcheck.sh
@@ -361,6 +361,11 @@ while [ $# -gt 0 ]; do
 			fi
 			nodefaults=
 			;;
+		--no-connect)
+			# used for /docker-entrypoint-initdb.d scripts
+			# where you definately don't want a connection test
+			connect_s=0
+			;;
 		--*)
 			test=${1#--}
 			;;

--- a/src/bci_build/package/mariadb/11.5/entrypoint.sh
+++ b/src/bci_build/package/mariadb/11.5/entrypoint.sh
@@ -121,6 +121,7 @@ mysql_get_config() {
 docker_temp_server_start() {
 	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" --wsrep_on=OFF \
 		--expire-logs-days=0 \
+		--skip-slave-start \
 		--loose-innodb_buffer_pool_load_at_startup=0 \
 		--skip-ssl --ssl-cert='' --ssl-key='' --ssl-ca='' \
 		&
@@ -224,7 +225,7 @@ docker_create_db_directories() {
 }
 
 _mariadb_version() {
-	echo -n "11.5.2-MariaDB"
+	echo -n "11.4.4-MariaDB"
 }
 
 # initializes the database directory
@@ -460,7 +461,6 @@ docker_setup_db() {
 	# To create replica user
 	local createReplicaUser=
 	local changeMasterTo=
-	local startReplica=
 	if  [ -n "$MARIADB_REPLICATION_USER" ] ; then
 		if [ -z "$MARIADB_MASTER_HOST" ]; then
 			# on master
@@ -473,7 +473,6 @@ docker_setup_db() {
 			# SC cannot follow how MARIADB_MASTER_PORT is assigned a default value.
 			# shellcheck disable=SC2153
 			changeMasterTo="CHANGE MASTER TO MASTER_HOST='$MARIADB_MASTER_HOST', MASTER_USER='$MARIADB_REPLICATION_USER', MASTER_PASSWORD='$rplPasswordEscaped', MASTER_PORT=$MARIADB_MASTER_PORT, MASTER_CONNECT_RETRY=10;"
-			startReplica="START REPLICA;"
 		fi
 	fi
 
@@ -504,7 +503,6 @@ docker_setup_db() {
 		${userGrants}
 
 		${changeMasterTo}
-		${startReplica}
 	EOSQL
 }
 
@@ -600,8 +598,7 @@ docker_mariadb_upgrade() {
 	fi
 	mysql_note "Starting temporary server"
 	docker_temp_server_start "$@" --skip-grant-tables \
-		--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-		--skip-slave-start
+		--loose-innodb_buffer_pool_dump_at_shutdown=0
 	mysql_note "Temporary server started."
 
 	docker_mariadb_backup_system
@@ -626,8 +623,7 @@ EOSQL
 			# need a restart as FLUSH PRIVILEGES isn't reversable
 			mysql_note "Restarting temporary server for upgrade"
 			docker_temp_server_start "$@" --skip-grant-tables \
-				--loose-innodb_buffer_pool_dump_at_shutdown=0 \
-				--skip-slave-start
+				--loose-innodb_buffer_pool_dump_at_shutdown=0
 		else
 			return 0
 		fi

--- a/src/bci_build/package/mariadb/11.5/healthcheck.sh
+++ b/src/bci_build/package/mariadb/11.5/healthcheck.sh
@@ -363,6 +363,11 @@ while [ $# -gt 0 ]; do
 			fi
 			nodefaults=
 			;;
+		--no-connect)
+			# used for /docker-entrypoint-initdb.d scripts
+			# where you definately don't want a connection test
+			connect_s=0
+			;;
 		--*)
 			test=${1#--}
 			;;

--- a/update-files.sh
+++ b/update-files.sh
@@ -25,9 +25,11 @@ command -v jq > /dev/null || { echo "we need jq installed for update to work"; e
 rm -f src/bci_build/package/mariadb/*/entrypoint.sh src/bci_build/package/mariadb/*/healthcheck.sh
 for v in $(jq -r '.mariadb | del(.version_format) | .[]' src/bci_build/package/package_versions.json | cut -d. -f1-2 | sort -u); do
     mkdir -p "src/bci_build/package/mariadb/$v"
+    upstream_version=$v
+    [ "$v" = "11.5" ] && upstream_version=11.4
     curl -sf -o "src/bci_build/package/mariadb/$v/LICENSE" "https://raw.githubusercontent.com/MariaDB/mariadb-docker/master/LICENSE"
-    curl -sf -o "src/bci_build/package/mariadb/$v/entrypoint.sh" "https://raw.githubusercontent.com/MariaDB/mariadb-docker/master/$v/docker-entrypoint.sh"
-    curl -sf -o "src/bci_build/package/mariadb/$v/healthcheck.sh" "https://raw.githubusercontent.com/MariaDB/mariadb-docker/master/$v/healthcheck.sh"
+    curl -sf -o "src/bci_build/package/mariadb/$v/entrypoint.sh" "https://raw.githubusercontent.com/MariaDB/mariadb-docker/master/$upstream_version/docker-entrypoint.sh"
+    curl -sf -o "src/bci_build/package/mariadb/$v/healthcheck.sh" "https://raw.githubusercontent.com/MariaDB/mariadb-docker/master/$upstream_version/healthcheck.sh"
 done
 
 # TODO add license to upstream helm chart repo and fetch it here


### PR DESCRIPTION
Upstream has dropped mariadb 11.5 dockerfiles, but we haven't updated in tumbleweed to 11.6 yet. map them to 11.5.