### PR TITLE
Switch mariadb* images to bci-micro

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -235,6 +235,10 @@ class BaseContainerImage(abc.ABC):
     #:   is not possible and will result in an error.
     custom_end: str = ""
 
+    #: This string is appended to the the build stage in a multistage build and can
+    #: contain arbitrary instructions valid for a :file:`Dockerfile`.
+    build_stage_custom_end: str | None = None
+
     #: A script that is put into :file:`config.sh` if a kiwi image is
     #: created. If a :file:`Dockerfile` based build is used then this script is
     #: prependend with a :py:const:`~bci_build.package.DOCKERFILE_RUN` and added

--- a/src/bci_build/package/cosign.py
+++ b/src/bci_build/package/cosign.py
@@ -7,6 +7,7 @@ from bci_build.package import ApplicationStackContainer
 from bci_build.package import ParseVersion
 from bci_build.package import Replacement
 from bci_build.package.helpers import generate_from_image_tag
+from bci_build.package.helpers import generate_package_version_check
 from bci_build.package.versions import format_version
 from bci_build.package.versions import get_pkg_version
 
@@ -21,6 +22,9 @@ COSIGN_CONTAINERS = [
         version="%%cosign_version%%",
         tag_version=format_version(
             cosign_ver := get_pkg_version("cosign", os_version), ParseVersion.MINOR
+        ),
+        build_stage_custom_end=generate_package_version_check(
+            "cosign", cosign_ver, ParseVersion.MINOR, use_target=True
         ),
         version_in_uid=False,
         additional_versions=[format_version(cosign_ver, ParseVersion.MAJOR)],

--- a/src/bci_build/package/helpers.py
+++ b/src/bci_build/package/helpers.py
@@ -7,14 +7,22 @@ from bci_build.package import _build_tag_prefix
 
 
 def generate_package_version_check(
-    pkg_name: str, pkg_version: str, parse_version: ParseVersion = ParseVersion.MINOR
+    pkg_name: str,
+    pkg_version: str,
+    parse_version: ParseVersion = ParseVersion.MINOR,
+    use_target: bool = False,
 ) -> str:
     """Generate a RUN instruction for a :file:`Dockerfile` that will fail if the
     package with the name ``pkg_name`` is not at the provided version
-    ``pkg_version``. The optional parameter ``parse_version`` allows you to
+    ``pkg_version``.
+
+    The optional parameter ``parse_version`` allows you to
     restrict the version check to only match the major, major+minor, or
     major+minor+patch version.
 
+    The optional parameter "use_target" generates a RUN instruction that checks
+    for the ``pkg_name`` in the directory `/target` which is used in multi-stage
+    builds.
     """
     cut_count = {
         ParseVersion.MAJOR: 1,
@@ -28,7 +36,9 @@ def generate_package_version_check(
         )
 
     return f"""# sanity check that the version from the tag is equal to the version of {pkg_name} that we expect
-{DOCKERFILE_RUN} [ "$(rpm -q --qf '%{{version}}' {pkg_name} | cut -d '.' -f -{cut_count})" = "{pkg_version}" ]"""
+{DOCKERFILE_RUN} \\
+    [ "$(rpm{' --root /target' if use_target else ''} -q --qf '%{{version}}' {pkg_name} | \\
+    cut -d '.' -f -{cut_count})" = "{pkg_version}" ]"""
 
 
 def generate_from_image_tag(os_version: OsVersion, container_name: str) -> str:

--- a/src/bci_build/templates.py
+++ b/src/bci_build/templates.py
@@ -55,6 +55,9 @@ COPY --from=target / /target
     zypper -n clean; \\
     {{ LOG_CLEAN }}
 {%- endif %}
+{%- if image.build_stage_custom_end %}
+{{ image.build_stage_custom_end }}
+{%- endif %}
 {% if image.from_target_image %}FROM {{ image.dockerfile_from_target_ref }}
 COPY --from=builder /target /{% endif %}
 # Define labels according to https://en.opensuse.org/Building_derived_containers


### PR DESCRIPTION
we don't need zypper in application images, so lets remove it from the container to reduce exposure for potential security alerts.