### PR TITLE
Install git-core for gitea-runner

### DIFF
--- a/src/bci_build/package/basecontainers.py
+++ b/src/bci_build/package/basecontainers.py
@@ -343,7 +343,7 @@ GITEA_RUNNER_CONTAINER = OsContainer(
         "obs-service-format_spec_file",
         "obs-service-source_validator",
         "typescript",
-        "git",
+        "git-core",
         *OsVersion.TUMBLEWEED.release_package_names,
     ],
     extra_files={"osc_checkout": OSC_CHECKOUT},


### PR DESCRIPTION
we don't need the full svn migration tooling, as gitea is already git based.