### PR TITLE
Set BcntSyncTag for multibuild dockerfiles

### DIFF
--- a/src/bci_build/templates.py
+++ b/src/bci_build/templates.py
@@ -34,6 +34,8 @@ DOCKERFILE_TEMPLATE = jinja2.Template(
 {% endfor -%}
 {%- if image.publish_registry.force_multiversion -%}#!ForceMultiVersion
 {% endif -%}
+{%- if image.crate and image.build_flavor %}#!BcntSyncTag: {{ image.package_name }}
+{% endif -%}
 {% if image.build_version %}#!BuildName: {{ image.build_name }}
 #!BuildVersion: {{ image.build_version }}
 {%- endif %}


### PR DESCRIPTION
The Appcollection registry cannot handle de-synced build counters, so sync our buildcounter with the main packages buildcounter.