### PR TITLE
Mark the init-image as a singleton container

### DIFF
--- a/src/bci_build/package/basecontainers.py
+++ b/src/bci_build/package/basecontainers.py
@@ -65,6 +65,10 @@ INIT_CONTAINERS = [
         pretty_name=f"{os_version.pretty_os_version_no_dash} Init",
         custom_description="Systemd environment for containers {based_on_container}. {podman_only}",
         package_list=["systemd", "gzip", *os_version.release_package_names],
+        is_singleton_image=(
+            # preserve backwards compatibility on already released distributions
+            os_version not in (OsVersion.SP6, OsVersion.TUMBLEWEED)
+        ),
         cmd=["/usr/lib/systemd/systemd"],
         extra_labels={
             "usage": "This container should only be used to build containers for daemons. Add your packages and enable services using systemctl."
@@ -169,6 +173,17 @@ FIPS_BASE_CONTAINERS = [
         os_version=os_version,
         build_recipe_type=BuildType.DOCKER,
         support_level=SupportLevel.L3,
+        is_singleton_image=(
+            # preserve backwards compatibility on already released distributions
+            os_version
+            not in (
+                OsVersion.SP3,
+                OsVersion.SP4,
+                OsVersion.SP5,
+                OsVersion.SP6,
+                OsVersion.TUMBLEWEED,
+            )
+        ),
         supported_until=_get_supported_until_fips(os_version),
         is_latest=(
             os_version in CAN_BE_LATEST_OS_VERSION or os_version in ALL_OS_LTSS_VERSIONS


### PR DESCRIPTION
This removes the "buildname" suffix that was considered an issue, but of course will break our entire CI testing and publishing pipeline.