### PR TITLE
Reduce unnecessary temporary list creation

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -1284,18 +1284,19 @@ class DevelopmentContainer(BaseContainerImage):
             if self.stability_tag:
                 ver_labels = [self.stability_tag] + ver_labels
             for ver_label in ver_labels:
-                tags += [
+                tags.append(
                     f"{self.registry_prefix}/{name}:{ver_label}-{self._release_suffix}"
-                ]
-                tags += [f"{self.registry_prefix}/{name}:{ver_label}"]
+                )
+                tags.append(f"{self.registry_prefix}/{name}:{ver_label}")
             additional_ver_labels: list[str] = self.additional_versions
             if self._version_variant != self._tag_variant:
                 additional_ver_labels = [self._tag_variant] + additional_ver_labels
-            for ver_label in additional_ver_labels:
-                tags += [f"{self.registry_prefix}/{name}:{ver_label}"]
-
+            tags.extend(
+                f"{self.registry_prefix}/{name}:{ver_label}"
+                for ver_label in additional_ver_labels
+            )
             if self.is_latest:
-                tags += [f"{self.registry_prefix}/{name}:latest"]
+                tags.append(f"{self.registry_prefix}/{name}:latest")
         return tags
 
     @property
@@ -1396,12 +1397,10 @@ class OsContainer(BaseContainerImage):
         tags: list[str] = []
 
         for name in [self.name] + self.additional_names:
-            tags += [
-                f"{self.registry_prefix}/bci-{name}:{self.image_ref_name}",
-                f"{self.registry_prefix}/bci-{name}:%OS_VERSION_ID_SP%",
-            ] + (
-                [f"{self.registry_prefix}/bci-{name}:latest"] if self.is_latest else []
-            )
+            tags.append(f"{self.registry_prefix}/bci-{name}:{self.image_ref_name}")
+            tags.append(f"{self.registry_prefix}/bci-{name}:%OS_VERSION_ID_SP%")
+            if self.is_latest:
+                tags.append(f"{self.registry_prefix}/bci-{name}:latest")
         return tags
 
     @property

--- a/src/bci_build/package/basecontainers.py
+++ b/src/bci_build/package/basecontainers.py
@@ -208,18 +208,18 @@ def _get_minimal_kwargs(os_version: OsVersion):
     if os_version in (OsVersion.SP6,):
         package_list.append(Package("libpcre1", pkg_type=PackageType.DELETE))
 
-    package_list += [
+    package_list.extend(
         Package(name, pkg_type=PackageType.BOOTSTRAP)
         for name in os_version.release_package_names
-    ]
+    )
     if os_version in (OsVersion.TUMBLEWEED, OsVersion.SLE16_0):
         package_list.append(Package("rpm", pkg_type=PackageType.BOOTSTRAP))
     else:
         # in SLE15, rpm still depends on Perl.
-        package_list += [
+        package_list.extend(
             Package(name, pkg_type=PackageType.BOOTSTRAP)
             for name in ("rpm-ndb", "perl-base")
-        ]
+        )
 
     kwargs = {
         "from_image": f"{_build_tag_prefix(os_version)}/bci-micro:{OsContainer.version_to_container_os_version(os_version)}",


### PR DESCRIPTION
postfix temporary lists are hard to read and slow the code down (not that would matter). Plus, it produces headaches.