### PR TITLE
Remove patterns-base-fips from SLFO base containers

### DIFF
--- a/src/bci_build/package/base.py
+++ b/src/bci_build/package/base.py
@@ -177,13 +177,12 @@ def _get_base_kwargs(os_version: OsVersion) -> dict:
                     "cracklib-dict-small",
                     "filesystem",
                     "jdupes",
-                    "patterns-base-fips",
                     "shadow",
                     "zypper",
                 ]
                 + (["libcurl-mini4"] if os_version.is_slfo else [])
                 + (
-                    ["kubic-locale-archive", "rpm-ndb"]
+                    ["kubic-locale-archive", "rpm-ndb", "patterns-base-fips"]
                     if os_version.is_sle15
                     else ["glibc-locale-base"]
                 )

--- a/src/bci_build/package/basecontainers.py
+++ b/src/bci_build/package/basecontainers.py
@@ -115,10 +115,9 @@ def _get_fips_base_custom_end(os_version: OsVersion) -> str:
             bins = _FIPS_15_SP2_BINARIES
         case OsVersion.SP4:
             bins = _FIPS_15_SP4_BINARIES
-        case OsVersion.SP5 | OsVersion.SP6:
-            pass
-        case _:
-            raise NotImplementedError(f"Unsupported os_version: {os_version}")
+
+    if os_version not in ALL_BASE_OS_VERSIONS:
+        raise NotImplementedError(f"Unsupported os_version: {os_version}")
 
     custom_install_bins: str = textwrap.dedent(
         f"""
@@ -141,13 +140,11 @@ def _get_fips_base_custom_end(os_version: OsVersion) -> str:
 
 
 def _get_fips_pretty_name(os_version: OsVersion) -> str:
-    match os_version:
-        case OsVersion.SP3:
-            return f"{os_version.pretty_os_version_no_dash} FIPS-140-2"
-        case OsVersion.SP4 | OsVersion.SP5 | OsVersion.SP6:
-            return f"{os_version.pretty_os_version_no_dash} FIPS-140-3"
-        case _:
-            raise NotImplementedError(f"Unsupported os_version: {os_version}")
+    if os_version == OsVersion.SP3:
+        return f"{os_version.pretty_os_version_no_dash} FIPS-140-2"
+    if os_version.is_sle15 or os_version.is_slfo or os_version.is_tumbleweed:
+        return f"{os_version.pretty_os_version_no_dash} FIPS-140-3"
+    raise NotImplementedError(f"Unsupported os_version: {os_version}")
 
 
 def _get_supported_until_fips(os_version: OsVersion) -> datetime.date:
@@ -198,7 +195,7 @@ FIPS_BASE_CONTAINERS = [
         ),
     )
     # SP5 is known to be having a non-working libgcrypt for FIPS mode
-    for os_version in (OsVersion.SP3, OsVersion.SP4, OsVersion.SP6)
+    for os_version in ALL_OS_VERSIONS - {OsVersion.SP5}
 ]
 
 

--- a/src/bci_build/package/basecontainers.py
+++ b/src/bci_build/package/basecontainers.py
@@ -173,11 +173,14 @@ FIPS_BASE_CONTAINERS = [
             os_version in CAN_BE_LATEST_OS_VERSION or os_version in ALL_OS_LTSS_VERSIONS
         ),
         pretty_name=_get_fips_pretty_name(os_version),
-        package_list=[*os_version.release_package_names, "coreutils"]
-        + (
-            ["fipscheck"]
-            if os_version == OsVersion.SP3
-            else ["crypto-policies-scripts"]
+        package_list=(
+            [*os_version.release_package_names, "coreutils"]
+            + (
+                ["fipscheck"]
+                if os_version == OsVersion.SP3
+                else ["crypto-policies-scripts"]
+            )
+            + (["patterns-base-fips"] if os_version.is_slfo else [])
         ),
         extra_labels={
             "usage": "This container should only be used on a FIPS enabled host (fips=1 on kernel cmdline)."


### PR DESCRIPTION
This is pulling crypto-policies and we have base-fips now instead.