### PR TITLE
Drop jshell as the CMD for openjdk-devel

### DIFF
--- a/src/bci_build/package/openjdk-devel/README.md.j2
+++ b/src/bci_build/package/openjdk-devel/README.md.j2
@@ -10,14 +10,14 @@ The OpenJDK development image is intended to be used as a build environment. For
 
 ## Usage
 
-The default command for the image is the Java Shell tool (JShell).
+{% if image.os_version | string in ("5", "6") %}The default command for the image is the Java Shell tool (JShell).
 
 ```ShellSession
 $ podman run -it --rm {{ image.pretty_reference }}
 jshell> /help
 ```
 
-To compile and deploy an application, copy the sources and build the binary:
+{% endif %}To compile and deploy an application, copy the sources and build the binary:
 
 ```Dockerfile
 # Build the application using the OpenJDK development image

--- a/src/bci_build/package/openjdk.py
+++ b/src/bci_build/package/openjdk.py
@@ -15,7 +15,9 @@ from bci_build.package import generate_disk_size_constraints
 
 
 def _get_openjdk_kwargs(
-    os_version: OsVersion,
+    os_version: Literal[
+        OsVersion.TUMBLEWEED, OsVersion.SP7, OsVersion.SP6, OsVersion.SP5
+    ],
     devel: bool,
     java_version: Literal[11, 13, 15, 17, 20, 21, 23],
 ):
@@ -61,12 +63,16 @@ def _get_openjdk_kwargs(
     }
 
     if devel:
+        # don't set CMD in SP7 onward as jshell is broken and the CMD is
+        # arguably not too useful anyway
+        if os_version in (OsVersion.SP5, OsVersion.SP6):
+            common |= {"cmd": ["/usr/bin/jshell"]}
+
         return common | {
             "name": "openjdk-devel",
             "custom_labelprefix_end": "openjdk.devel",
             "pretty_name": f"OpenJDK {java_version} development",
             "package_list": [f"java-{java_version}-openjdk-devel", "maven"],
-            "cmd": ["/usr/bin/jshell"],
             "from_image": f"{_build_tag_prefix(os_version)}/openjdk:{java_version}",
         }
     return common | {


### PR DESCRIPTION
`jshell` is broken on ppc64le for mysterious reasons and it's not really a useful `CMD` anyway, so let's just stop using it by default until someone complains