### PR TITLE
Readd the fips provider into the base-image

### DIFF
--- a/src/bci_build/package/base.py
+++ b/src/bci_build/package/base.py
@@ -180,7 +180,11 @@ def _get_base_kwargs(os_version: OsVersion) -> dict:
                     "shadow",
                     "zypper",
                 ]
-                + (["libcurl-mini4"] if os_version.is_slfo else [])
+                + (
+                    ["libcurl-mini4", "libopenssl-3-fips-provider"]
+                    if os_version.is_slfo
+                    else []
+                )
                 + (
                     ["kubic-locale-archive", "rpm-ndb", "patterns-base-fips"]
                     if os_version.is_sle15


### PR DESCRIPTION
This was dropped via the drop of the patterns-base-fips, but we still need it to make the image FIPS compatible.