### PR TITLE
Helm version check

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -1456,7 +1456,6 @@ from .apache_tomcat import TOMCAT_CONTAINERS  # noqa: E402
 from .appcontainers import ALERTMANAGER_CONTAINERS  # noqa: E402
 from .appcontainers import BLACKBOX_EXPORTER_CONTAINERS  # noqa: E402
 from .appcontainers import GRAFANA_CONTAINERS  # noqa: E402
-from .appcontainers import HELM_CONTAINERS  # noqa: E402
 from .appcontainers import NGINX_CONTAINERS  # noqa: E402
 from .appcontainers import PCP_CONTAINERS  # noqa: E402
 from .appcontainers import PROMETHEUS_CONTAINERS  # noqa: E402
@@ -1475,6 +1474,7 @@ from .cosign import COSIGN_CONTAINERS  # noqa: E402
 from .gcc import GCC_CONTAINERS  # noqa: E402
 from .git import GIT_CONTAINERS  # noqa: E402
 from .golang import GOLANG_CONTAINERS  # noqa: E402
+from .helm import HELM_CONTAINERS  # noqa: E402
 from .kea import KEA_DHCP_CONTAINERS  # noqa: E402
 from .kiwi import KIWI_CONTAINERS  # noqa: E402
 from .mariadb import MARIADB_CLIENT_CONTAINERS  # noqa: E402

--- a/src/bci_build/package/appcontainers.py
+++ b/src/bci_build/package/appcontainers.py
@@ -386,32 +386,6 @@ REGISTRY_CONTAINERS = [
 ]
 
 
-HELM_CONTAINERS = [
-    ApplicationStackContainer(
-        name="helm",
-        pretty_name="Kubernetes Package Manager",
-        from_image=generate_from_image_tag(os_version, "bci-micro"),
-        os_version=os_version,
-        is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
-        version=get_pkg_version("helm", os_version),
-        version_in_uid=False,
-        license="Apache-2.0",
-        package_list=[
-            Package(name, pkg_type=PackageType.BOOTSTRAP)
-            for name in (
-                "ca-certificates-mozilla",
-                "helm",
-            )
-        ],
-        entrypoint=["/usr/bin/helm"],
-        cmd=["help"],
-        build_recipe_type=BuildType.KIWI,
-        support_level=SupportLevel.L3,
-    )
-    for os_version in ALL_NONBASE_OS_VERSIONS
-]
-
-
 TRIVY_CONTAINERS = [
     ApplicationStackContainer(
         name="trivy",

--- a/src/bci_build/package/helm.py
+++ b/src/bci_build/package/helm.py
@@ -7,7 +7,11 @@ from bci_build.os_version import ALL_NONBASE_OS_VERSIONS
 from bci_build.os_version import CAN_BE_LATEST_OS_VERSION
 from bci_build.package import ApplicationStackContainer
 from bci_build.package import Package
+from bci_build.package import ParseVersion
+from bci_build.package import Replacement
 from bci_build.package.helpers import generate_from_image_tag
+from bci_build.package.helpers import generate_package_version_check
+from bci_build.package.versions import format_version
 from bci_build.package.versions import get_pkg_version
 
 HELM_CONTAINERS = [
@@ -17,7 +21,13 @@ HELM_CONTAINERS = [
         from_image=generate_from_image_tag(os_version, "bci-micro"),
         os_version=os_version,
         is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
-        version=get_pkg_version("helm", os_version),
+        version="%%helm_version%%",
+        tag_version=format_version(
+            helm_ver := get_pkg_version("helm", os_version), ParseVersion.MINOR
+        ),
+        config_sh_script=generate_package_version_check(
+            "helm", helm_ver, ParseVersion.MINOR
+        ),
         version_in_uid=False,
         license="Apache-2.0",
         package_list=[
@@ -25,6 +35,13 @@ HELM_CONTAINERS = [
             for name in (
                 "ca-certificates-mozilla",
                 "helm",
+            )
+        ],
+        replacements_via_service=[
+            Replacement(
+                regex_in_build_description="%%helm_version%%",
+                package_name="helm",
+                parse_version=ParseVersion.PATCH,
             )
         ],
         entrypoint=["/usr/bin/helm"],

--- a/src/bci_build/package/helm.py
+++ b/src/bci_build/package/helm.py
@@ -1,0 +1,36 @@
+"""BCI Container definition for the helm container."""
+
+from bci_build.container_attributes import BuildType
+from bci_build.container_attributes import PackageType
+from bci_build.container_attributes import SupportLevel
+from bci_build.os_version import ALL_NONBASE_OS_VERSIONS
+from bci_build.os_version import CAN_BE_LATEST_OS_VERSION
+from bci_build.package import ApplicationStackContainer
+from bci_build.package import Package
+from bci_build.package.helpers import generate_from_image_tag
+from bci_build.package.versions import get_pkg_version
+
+HELM_CONTAINERS = [
+    ApplicationStackContainer(
+        name="helm",
+        pretty_name="Kubernetes Package Manager",
+        from_image=generate_from_image_tag(os_version, "bci-micro"),
+        os_version=os_version,
+        is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
+        version=get_pkg_version("helm", os_version),
+        version_in_uid=False,
+        license="Apache-2.0",
+        package_list=[
+            Package(name, pkg_type=PackageType.BOOTSTRAP)
+            for name in (
+                "ca-certificates-mozilla",
+                "helm",
+            )
+        ],
+        entrypoint=["/usr/bin/helm"],
+        cmd=["help"],
+        build_recipe_type=BuildType.KIWI,
+        support_level=SupportLevel.L3,
+    )
+    for os_version in ALL_NONBASE_OS_VERSIONS
+]

--- a/src/bci_build/package/helm.py
+++ b/src/bci_build/package/helm.py
@@ -1,12 +1,9 @@
 """BCI Container definition for the helm container."""
 
-from bci_build.container_attributes import BuildType
-from bci_build.container_attributes import PackageType
 from bci_build.container_attributes import SupportLevel
 from bci_build.os_version import ALL_NONBASE_OS_VERSIONS
 from bci_build.os_version import CAN_BE_LATEST_OS_VERSION
 from bci_build.package import ApplicationStackContainer
-from bci_build.package import Package
 from bci_build.package import ParseVersion
 from bci_build.package import Replacement
 from bci_build.package.helpers import generate_from_image_tag
@@ -18,7 +15,6 @@ HELM_CONTAINERS = [
     ApplicationStackContainer(
         name="helm",
         pretty_name="Kubernetes Package Manager",
-        from_image=generate_from_image_tag(os_version, "bci-micro"),
         os_version=os_version,
         is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
         version="%%helm_version%%",
@@ -28,17 +24,15 @@ HELM_CONTAINERS = [
         additional_versions=[
             format_version(helm_ver, ParseVersion.MAJOR),
         ],
-        config_sh_script=generate_package_version_check(
-            "helm", helm_ver, ParseVersion.MINOR
+        from_target_image=generate_from_image_tag(os_version, "bci-micro"),
+        build_stage_custom_end=generate_package_version_check(
+            "helm", helm_ver, ParseVersion.MINOR, use_target=True
         ),
         version_in_uid=False,
         license="Apache-2.0",
         package_list=[
-            Package(name, pkg_type=PackageType.BOOTSTRAP)
-            for name in (
-                "ca-certificates-mozilla",
-                "helm",
-            )
+            "ca-certificates-mozilla",
+            "helm",
         ],
         replacements_via_service=[
             Replacement(
@@ -49,7 +43,6 @@ HELM_CONTAINERS = [
         ],
         entrypoint=["/usr/bin/helm"],
         cmd=["help"],
-        build_recipe_type=BuildType.KIWI,
         support_level=SupportLevel.L3,
     )
     for os_version in ALL_NONBASE_OS_VERSIONS

--- a/src/bci_build/package/helm.py
+++ b/src/bci_build/package/helm.py
@@ -25,6 +25,9 @@ HELM_CONTAINERS = [
         tag_version=format_version(
             helm_ver := get_pkg_version("helm", os_version), ParseVersion.MINOR
         ),
+        additional_versions=[
+            format_version(helm_ver, ParseVersion.MAJOR),
+        ],
         config_sh_script=generate_package_version_check(
             "helm", helm_ver, ParseVersion.MINOR
         ),

--- a/src/bci_build/package/helm/README.md.j2
+++ b/src/bci_build/package/helm/README.md.j2
@@ -19,7 +19,7 @@ $ podman run --rm -it  {{ image.pretty_reference }} <helm-sub-command>
 For instance, to display the Helm version, run:
 ```ShellSession
 $ podman run --rm -it {{ image.pretty_reference }} version {% raw %}--template='{{.Version}}'{% endraw %}
-v{{ image.version }}
+v{{ image.tag_version }}
 ```
 
 Refer to the full list of Helm commands, flags and environment variables, in the [official Helm documentation](https://helm.sh/docs/helm/helm/).


### PR DESCRIPTION
Fix helm version handling
   
Ensure we fail the build when the version number is not the expected one. use the full version as tag and also set a tag_version.