### PR TITLE
Limit the go version to three components

### DIFF
--- a/src/bci_build/package/golang.py
+++ b/src/bci_build/package/golang.py
@@ -10,6 +10,7 @@ from bci_build.os_version import OsVersion
 from bci_build.package import DOCKERFILE_RUN
 from bci_build.package import LOG_CLEAN
 from bci_build.package import DevelopmentContainer
+from bci_build.package import ParseVersion
 from bci_build.package import Replacement
 from bci_build.package import generate_disk_size_constraints
 
@@ -57,7 +58,9 @@ def _get_golang_kwargs(
         },
         "replacements_via_service": [
             Replacement(
-                regex_in_build_description=golang_version_regex, package_name=go
+                regex_in_build_description=golang_version_regex,
+                package_name=go,
+                parse_version=ParseVersion.PATCH,
             )
         ],
         "custom_end": textwrap.dedent(


### PR DESCRIPTION
The go-openssl variant has/had a four component version which confuses the heck out of the go ecosystem. Therefore @jfkw patched go-openssl to no longer output the fourth component, but now we have a mismatch between the output go-openssl version and the go-openssl rpm package version.

By setting the replace_using_package_version service to parse the patch version, we hopefully eliminate this discrepancy in the `GOLANG_VERSION` environment variable.