### PR TITLE
Switch SP6+ to public-dl.suse.com

### DIFF
--- a/src/bci_build/package/base.py
+++ b/src/bci_build/package/base.py
@@ -55,9 +55,9 @@ sed -i 's/.*rpm.install.excludedocs.*/rpm.install.excludedocs = yes/g' /etc/zypp
 #======================================
 # Configure SLE BCI repositories
 #--------------------------------------
-zypper -n ar --refresh --gpgcheck --priority 100 --enable 'https://installer-updates.suse.com/SUSE/Products/SLE-BCI/$releasever_major-SP$releasever_minor/$basearch/product/' SLE_BCI
-zypper -n ar --refresh --gpgcheck --priority 100 --disable 'https://installer-updates.suse.com/SUSE/Products/SLE-BCI/$releasever_major-SP$releasever_minor/$basearch/product_debug/' SLE_BCI_debug
-zypper -n ar --refresh --gpgcheck --priority 100 --disable 'https://installer-updates.suse.com/SUSE/Products/SLE-BCI/$releasever_major-SP$releasever_minor/$basearch/product_source/' SLE_BCI_source
+zypper -n ar --refresh --gpgcheck --priority 100 --enable 'https://public-dl.suse.com/SUSE/Products/SLE-BCI/$releasever_major-SP$releasever_minor/$basearch/product/' SLE_BCI
+zypper -n ar --refresh --gpgcheck --priority 100 --disable 'https://public-dl.suse.com/SUSE/Products/SLE-BCI/$releasever_major-SP$releasever_minor/$basearch/product_debug/' SLE_BCI_debug
+zypper -n ar --refresh --gpgcheck --priority 100 --disable 'https://public-dl.suse.com/SUSE/Products/SLE-BCI/$releasever_major-SP$releasever_minor/$basearch/product_source/' SLE_BCI_source
 {%- endif %}
 
 #======================================


### PR DESCRIPTION
We'll move installer-updates to a fixed-ip setup to maximize interoperability. However BCI should use the direct CDN link, so switch to that.