### PR TITLE
Switch golang-stable to 1.24

### DIFF
--- a/src/bci_build/package/golang.py
+++ b/src/bci_build/package/golang.py
@@ -14,12 +14,15 @@ from bci_build.package import ParseVersion
 from bci_build.package import Replacement
 from bci_build.package import generate_disk_size_constraints
 
-_GO_VER_T = Literal["1.20", "1.21", "1.22", "1.23"]
-_GOLANG_VERSIONS: list[_GO_VER_T] = ["1.22", "1.23"]
+_GO_VER_T = Literal["1.20", "1.21", "1.22", "1.23", "1.24"]
+_GOLANG_VERSIONS: list[_GO_VER_T] = ["1.23", "1.24"]
 _GOLANG_OPENSSL_VERSIONS: list[_GO_VER_T] = ["1.22", "1.23"]
 _GOLANG_VARIANT_T = Literal["", "-openssl"]
 
 assert len(_GOLANG_VERSIONS) == 2, "Only two golang versions must be supported"
+assert len(_GOLANG_OPENSSL_VERSIONS) == 2, (
+    "Only two golang-openssl versions must be supported"
+)
 
 
 def _get_golang_kwargs(


### PR DESCRIPTION
(scheduled for early february)