### PR TITLE
Disable some containers on 32-bit arm

### DIFF
--- a/src/bci_build/package/appcontainers.py
+++ b/src/bci_build/package/appcontainers.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 from bci_build.container_attributes import TCP
+from bci_build.container_attributes import Arch
 from bci_build.container_attributes import BuildType
 from bci_build.container_attributes import PackageType
 from bci_build.container_attributes import SupportLevel
@@ -101,6 +102,7 @@ THREE_EIGHT_NINE_DS_CONTAINERS = [
     ApplicationStackContainer(
         name="389-ds",
         package_name="389-ds-container",
+        exclusive_arch=[Arch.AARCH64, Arch.PPC64LE, Arch.S390X, Arch.X86_64],
         os_version=os_version,
         is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
         version_in_uid=False,

--- a/src/bci_build/package/helm.py
+++ b/src/bci_build/package/helm.py
@@ -1,5 +1,6 @@
 """BCI Container definition for the helm container."""
 
+from bci_build.container_attributes import Arch
 from bci_build.container_attributes import SupportLevel
 from bci_build.os_version import ALL_NONBASE_OS_VERSIONS
 from bci_build.os_version import CAN_BE_LATEST_OS_VERSION
@@ -15,6 +16,7 @@ HELM_CONTAINERS = [
     ApplicationStackContainer(
         name="helm",
         pretty_name="Helm (Kubernetes Package Manager)",
+        exclusive_arch=[Arch.AARCH64, Arch.PPC64LE, Arch.S390X, Arch.X86_64],
         os_version=os_version,
         is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
         version="%%helm_version%%",

--- a/src/bci_build/package/kubectl.py
+++ b/src/bci_build/package/kubectl.py
@@ -1,5 +1,6 @@
 """Kubectl BCI container"""
 
+from bci_build.container_attributes import Arch
 from bci_build.container_attributes import SupportLevel
 from bci_build.os_version import CAN_BE_LATEST_OS_VERSION
 from bci_build.os_version import OsVersion
@@ -28,6 +29,7 @@ KUBECTL_CONTAINERS = [
         package_name=f"kubectl-{ver}-image",
         pretty_name="kubectl",
         custom_description="Kubernetes CLI for communicating with a Kubernetes cluster's control plane, using the Kubernetes API.",
+        exclusive_arch=[Arch.AARCH64, Arch.PPC64LE, Arch.S390X, Arch.X86_64],
         os_version=os_version,
         is_latest=_is_latest_kubectl(ver, os_version),
         version="%%kubectl_version%%",

--- a/src/bci_build/package/mariadb.py
+++ b/src/bci_build/package/mariadb.py
@@ -4,6 +4,7 @@ import re
 from pathlib import Path
 
 from bci_build.container_attributes import TCP
+from bci_build.container_attributes import Arch
 from bci_build.container_attributes import BuildType
 from bci_build.container_attributes import SupportLevel
 from bci_build.os_version import ALL_NONBASE_OS_VERSIONS
@@ -70,6 +71,7 @@ for os_version in ALL_NONBASE_OS_VERSIONS:
             version=_MARIADB_VERSION_PLACEHOLDER,
             tag_version=mariadb_version,
             additional_names=additional_names,
+            exclusive_arch=[Arch.AARCH64, Arch.PPC64LE, Arch.S390X, Arch.X86_64],
             os_version=os_version,
             is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
             version_in_uid=False,
@@ -152,6 +154,7 @@ COPY idexec /usr/local/bin/idexec
     MARIADB_CLIENT_CONTAINERS.append(
         ApplicationStackContainer(
             name=f"{prefix}mariadb-client",
+            exclusive_arch=[Arch.AARCH64, Arch.PPC64LE, Arch.S390X, Arch.X86_64],
             os_version=os_version,
             is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
             version_in_uid=False,


### PR DESCRIPTION
Disable kubectl, 389-ds, helm and mariadb containers on 32-bit arm