### PR TITLE
Ensure the branch filter is treated as string in yaml

### DIFF
--- a/src/staging/bot.py
+++ b/src/staging/bot.py
@@ -369,7 +369,7 @@ class StagingBot:
     event: push
     branches:
       only:
-        - {self.deployment_branch_name}
+        - "{self.deployment_branch_name}"
 """
 
         workflows = """---


### PR DESCRIPTION
Without quotes, strings like 16.0 is parsed as float which confuses the build service, parsing it as 16 then instead.