### PR TITLE
Remove postfix and Tomcat from the AppCollection

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -1490,7 +1490,6 @@ from .python import PYTHON_3_11_CONTAINERS  # noqa: E402
 from .python import PYTHON_3_12_CONTAINERS  # noqa: E402
 from .python import PYTHON_3_13_CONTAINERS  # noqa: E402
 from .python import PYTHON_TW_CONTAINERS  # noqa: E402
-from .python import SAC_PYTHON_CONTAINERS  # noqa: E402
 from .rmt import RMT_CONTAINERS  # noqa: E402
 from .ruby import RUBY_CONTAINERS  # noqa: E402
 from .rust import RUST_CONTAINERS  # noqa: E402
@@ -1504,7 +1503,6 @@ ALL_CONTAINER_IMAGE_NAMES: dict[str, BaseContainerImage] = {
     for bci in (
         *BASE_CONTAINERS,
         *COSIGN_CONTAINERS,
-        *SAC_PYTHON_CONTAINERS,
         *PYTHON_3_6_CONTAINERS,
         *PYTHON_3_11_CONTAINERS,
         *PYTHON_3_12_CONTAINERS,

--- a/src/bci_build/package/postfix.py
+++ b/src/bci_build/package/postfix.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 from bci_build.container_attributes import TCP
 from bci_build.container_attributes import SupportLevel
-from bci_build.os_version import ALL_NONBASE_OS_VERSIONS
 from bci_build.os_version import CAN_BE_LATEST_OS_VERSION
 from bci_build.os_version import OsVersion
 from bci_build.package import DOCKERFILE_RUN
@@ -12,7 +11,6 @@ from bci_build.package import ApplicationStackContainer
 from bci_build.package import ParseVersion
 from bci_build.package import Replacement
 from bci_build.package.helpers import generate_from_image_tag
-from bci_build.registry import ApplicationCollectionRegistry
 
 _POSTFIX_FILES = {}
 for filename in (
@@ -38,10 +36,6 @@ for filename in (
 POSTFIX_CONTAINERS = [
     ApplicationStackContainer(
         name="postfix",
-        package_name=None if os_version.is_tumbleweed else "sac-postfix-image",
-        _publish_registry=(
-            None if os_version.is_tumbleweed else ApplicationCollectionRegistry()
-        ),
         pretty_name="Postfix",
         custom_description="Postfix container is fast and secure mail server, {based_on_container}.",
         os_version=os_version,
@@ -103,5 +97,5 @@ HEALTHCHECK --interval=5s --timeout=10s --start-period=30s --retries=3 \
         CMD postfix status
 """,
     )
-    for os_version in ALL_NONBASE_OS_VERSIONS
+    for os_version in (OsVersion.TUMBLEWEED,)
 ]

--- a/src/bci_build/package/python.py
+++ b/src/bci_build/package/python.py
@@ -10,7 +10,6 @@ from bci_build.os_version import _SUPPORTED_UNTIL_SLE
 from bci_build.os_version import OsVersion
 from bci_build.package import DevelopmentContainer
 from bci_build.package import Replacement
-from bci_build.registry import publish_registry
 
 _PYTHON_VERSIONS = Literal["3.6", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
@@ -111,16 +110,6 @@ def _get_python_kwargs(py3_ver: _PYTHON_VERSIONS, os_version: OsVersion):
 
     return kwargs
 
-
-SAC_PYTHON_CONTAINERS = [
-    PythonDevelopmentContainer(
-        **_get_python_kwargs(py_version, OsVersion.SP6),
-        package_name=f"sac-python-{py_version}-image",
-        buildcounter_synctag="sac-containers-python",
-        _publish_registry=publish_registry(OsVersion.SP6, app_collection=True),
-    )
-    for py_version in ("3.9", "3.11")
-]
 
 PYTHON_3_6_CONTAINERS = (
     PythonDevelopmentContainer(


### PR DESCRIPTION
The appcollection team decided to package them by themselves, these containers are hence unused and we don't need to be maintaining them anymore.