### PR TITLE
Switch tracking of version to minor-version for spack

### DIFF
--- a/src/bci_build/package/package_versions.json
+++ b/src/bci_build/package/package_versions.json
@@ -68,9 +68,10 @@
         "version_format": "minor"
     },
     "spack": {
-        "6": "0.23.1",
-        "7": "0.23.0",
-        "Tumbleweed": "0.23.1"
+        "6": "0.23",
+        "7": "0.23",
+        "Tumbleweed": "0.23",
+        "version_format": "minor"
     },
     "valkey": {
         "6": "8.0",

--- a/src/bci_build/package/spack/README.md.j2
+++ b/src/bci_build/package/spack/README.md.j2
@@ -1,4 +1,4 @@
-# Spack {{ image.version }} container image
+# Spack {{ image.tag_version }} container image
 {% include 'badges.j2' %}
 
 ## Description


### PR DESCRIPTION
This helps with mismatches on unreleased codestreams where we have build issues that are not seen in OBS yet (where the versions are being fetched from).