### PR TITLE
Ensure that os_version has a stable value in the slm60 container

### DIFF
--- a/src/bci_build/package/basecontainers.py
+++ b/src/bci_build/package/basecontainers.py
@@ -355,7 +355,7 @@ KERNEL_MODULE_CONTAINERS.append(
         name="slm60-kernel-module-devel",
         pretty_name="SUSE Linux Micro 6.0 Kernel module development",
         logo_url="https://opensource.suse.com/bci/SLE_BCI_logomark_green.svg",
-        os_version=OsVersion.SLE16_0,
+        os_version=(os_version := OsVersion.SLE16_0),
         supported_until=_SUPPORTED_UNTIL_SLE.get(os_version),
         is_latest=True,
         package_list=(
@@ -368,7 +368,7 @@ KERNEL_MODULE_CONTAINERS.append(
                 "pesign-obs-integration",
                 "dwarves",
                 "libelf-devel",
-                *OsVersion.SLE16_0.release_package_names,
+                *os_version.release_package_names,
             ]
         ),
         exclusive_arch=[Arch.X86_64, Arch.S390X, Arch.AARCH64],


### PR DESCRIPTION
The value of `os_version` comes from the previous loop and its value is not stable, leading to fun stuff like:
https://github.com/SUSE/BCI-dockerfile-generator/pull/2393 

Defining it using the walrus operator ensures that it has the correct value