### PR TITLE
Adjust ownership of /var/lib/named/master on Tumbleweed

### DIFF
--- a/src/bci_build/package/bind.py
+++ b/src/bci_build/package/bind.py
@@ -74,7 +74,11 @@ COPY healthcheck.sh {(_healthcheck := "/usr/local/bin/healthcheck.sh")}
                     ("/run/named", "1775", "root:named"),
                     ("/var/lib/named", "1775", "root:named"),
                     ("/var/lib/named/dyn", "755", "named:named"),
-                    ("/var/lib/named/master", "755", "named:named"),
+                    (
+                        "/var/lib/named/master",
+                        "755",
+                        "root:root" if os_version.is_tumbleweed else "named:named",
+                    ),
                     ("/var/lib/named/slave", "755", "named:named"),
                     ("/var/log/named", "750", "named:named"),
                 )


### PR DESCRIPTION
`/usr/lib/tmpfiles.d/bind.conf` contains the following line on TW: 
```
d	/var/lib/named/master		755	root	root	-	-
```
whereas it contains this on SLE 15:
```
d /var/lib/named/master 755 named named - -
```
=> We need a conditional for TW