### PR TITLE
Set the registry prefix to opensuse/bci for all images

### DIFF
--- a/src/bci_build/registry.py
+++ b/src/bci_build/registry.py
@@ -115,7 +115,7 @@ class openSUSERegistry(Registry):
 
     @staticmethod
     def registry_prefix(*, is_application: bool) -> str:
-        return "opensuse" if is_application else "opensuse/bci"
+        return "opensuse/bci"
 
 
 def publish_registry(


### PR DESCRIPTION
This prevents clashes with the openSUSE container images