### PR TITLE
add libpulse0 to fix audio issue with firefox

### DIFF
--- a/src/bci_build/package/firefox.py
+++ b/src/bci_build/package/firefox.py
@@ -24,6 +24,8 @@ FIREFOX_CONTAINERS = [
                 "MozillaFirefox",
                 # for fonts to actually display
                 "xorg-x11-fonts",
+                # for puleaudio communication
+                "libpulse0"
             ]
             + (
                 ["MozillaFirefox-branding-openSUSE"]

--- a/src/bci_build/package/firefox.py
+++ b/src/bci_build/package/firefox.py
@@ -25,7 +25,7 @@ FIREFOX_CONTAINERS = [
                 # for fonts to actually display
                 "xorg-x11-fonts",
                 # for puleaudio communication
-                "libpulse0"
+                "libpulse0",
             ]
             + (
                 ["MozillaFirefox-branding-openSUSE"]


### PR DESCRIPTION
Add missing package libpulse0 which is required for puleaudio communication.