### PR TITLE
Switch bci-micro build to use docker rather than kiwi

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -603,6 +603,8 @@ exit 0
         """Provide the reference for the target image if multistage build is used, empty string otherwise."""
         if not self.from_target_image:
             return ""
+        if self.from_target_image == "scratch":
+            return self.from_target_image
         # build against the released container on SLE for proper base.digest/name generation
         return (
             self.from_target_image

--- a/src/bci_build/package/basecontainers.py
+++ b/src/bci_build/package/basecontainers.py
@@ -47,12 +47,14 @@ MICRO_CONTAINERS = [
         is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
         pretty_name=f"{os_version.pretty_os_version_no_dash} Micro",
         custom_description="A micro environment for containers {based_on_container}.",
-        from_image=None,
-        build_recipe_type=BuildType.KIWI,
-        package_list=_get_micro_package_list(os_version),
-        # intentionally empty
-        config_sh_script="""
-""",
+        from_target_image="scratch",
+        cmd=["/bin/sh"],
+        package_list=[pkg.name for pkg in _get_micro_package_list(os_version)],
+        build_stage_custom_end=textwrap.dedent(
+            f"""
+            {DOCKERFILE_RUN} zypper -n install jdupes \\
+                && jdupes -1 -L -r /target/usr/"""
+        ),
     )
     for os_version in ALL_BASE_OS_VERSIONS
 ]

--- a/src/bci_build/templates.py
+++ b/src/bci_build/templates.py
@@ -48,15 +48,13 @@ COPY --from=target / /target
 {%- endif %}
 
 {% if image.packages %}{{ DOCKERFILE_RUN }} \\
-    zypper -n {%- if image.from_target_image %} --installroot /target --gpg-auto-import-keys {%- endif %} install {% if image.no_recommends %}--no-recommends {% endif %}{{ image.packages }}; \\
-    {%- if image.packages_to_delete %}
-    zypper -n {%- if image.from_target_image %} --installroot /target {%- endif %} remove {{ image.packages_to_delete }}; \\
-    {%- endif %}
-    zypper -n clean; \\
-    {{ LOG_CLEAN }}
-{%- endif %}
+    zypper -n {%- if image.from_target_image %} --installroot /target --gpg-auto-import-keys {%- endif %} install {% if image.no_recommends %}--no-recommends {% endif %}{{ image.packages }}{%- if image.packages_to_delete %} \\
+    zypper -n {%- if image.from_target_image %} --installroot /target {%- endif %} remove {{ image.packages_to_delete }}{%- endif %}{%- endif %}
 {%- if image.build_stage_custom_end %}
 {{ image.build_stage_custom_end }}
+{%- endif %}
+{% if image.packages %}{{ DOCKERFILE_RUN }} zypper -n {%- if image.from_target_image %} --installroot /target {%- endif %} clean -a; \\
+    {{ LOG_CLEAN }}
 {%- endif %}
 {% if image.from_target_image %}FROM {{ image.dockerfile_from_target_ref }}
 COPY --from=builder /target /{% endif %}

--- a/tests/test_build_recipe.py
+++ b/tests/test_build_recipe.py
@@ -35,8 +35,8 @@ from bci_build.templates import KIWI_TEMPLATE
 FROM registry.suse.com/bci/bci-base:15.6
 
 RUN \\
-    zypper -n install --no-recommends gcc emacs; \\
-    zypper -n clean; \\
+    zypper -n install --no-recommends gcc emacs
+RUN zypper -n clean -a; \\
     ##LOGCLEAN##
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
@@ -152,8 +152,8 @@ RUN emacs -Q --batch test.el
 FROM bci/bci-base:15.7
 
 RUN \\
-    zypper -n install --no-recommends gcc emacs; \\
-    zypper -n clean; \\
+    zypper -n install --no-recommends gcc emacs
+RUN zypper -n clean -a; \\
     ##LOGCLEAN##
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
@@ -256,8 +256,8 @@ Copyright header
 FROM registry.suse.com/bci/bci-base:15.6
 
 RUN \\
-    zypper -n install --no-recommends gcc emacs; \\
-    zypper -n clean; \\
+    zypper -n install --no-recommends gcc emacs
+RUN zypper -n clean -a; \\
     ##LOGCLEAN##
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
@@ -370,8 +370,8 @@ Copyright header
 FROM suse/base:18
 
 RUN \\
-    zypper -n install --no-recommends gcc emacs; \\
-    zypper -n clean; \\
+    zypper -n install --no-recommends gcc emacs
+RUN zypper -n clean -a; \\
     ##LOGCLEAN##
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
@@ -632,8 +632,8 @@ FROM bci/bci-base:15.6 AS builder
 COPY --from=target / /target
 
 RUN \\
-    zypper -n --installroot /target --gpg-auto-import-keys install --no-recommends emacs; \\
-    zypper -n clean; \\
+    zypper -n --installroot /target --gpg-auto-import-keys install --no-recommends emacs
+RUN zypper -n --installroot /target clean -a; \\
     ##LOGCLEAN##
 FROM registry.suse.com/bci/bci-micro:15.6
 COPY --from=builder /target /


### PR DESCRIPTION
This allows to run jdupes and avoids a bit of leftover garbage in the container, saving about 1.2MB (5%) of size on x86_64