### PR TITLE
Add entrypoint script for PulseAudio container

### DIFF
--- a/src/bci_build/package/pulseaudio.py
+++ b/src/bci_build/package/pulseaudio.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from bci_build.os_version import ALL_NONBASE_OS_VERSIONS
 from bci_build.os_version import CAN_BE_LATEST_OS_VERSION
+from bci_build.package import DOCKERFILE_RUN
 from bci_build.package import ApplicationStackContainer
 from bci_build.package import ParseVersion
 from bci_build.package import Replacement
@@ -19,6 +20,7 @@ _PULSE_FILES = {
     ).read_text(),
     "daemon.conf": (_pa_dir / "daemon.conf").read_text(),
     "system.pa": (_pa_dir / "system.pa").read_text(),
+    "entrypoint.sh": (_pa_dir / "entrypoint.sh").read_text(),
 }
 
 PULSEAUDIO_CONTAINERS = [
@@ -40,14 +42,16 @@ PULSEAUDIO_CONTAINERS = [
             )
         ],
         extra_files=_PULSE_FILES,
-        cmd=["/usr/bin/pulseaudio"],
+        entrypoint=["/usr/local/bin/entrypoint.sh"],
         custom_end=generate_package_version_check(
             "pulseaudio", tag_ver, ParseVersion.MAJOR
         )
-        + """
+        + rf"""
 COPY daemon.conf /etc/pulse/
 COPY client.conf /etc/pulse/
 COPY system.pa /etc/pulse/
+COPY entrypoint.sh /usr/local/bin/
+{DOCKERFILE_RUN} chmod +x /usr/local/bin/entrypoint.sh;
 """,
     )
     for os_version in ALL_NONBASE_OS_VERSIONS

--- a/src/bci_build/package/pulseaudio/entrypoint.sh
+++ b/src/bci_build/package/pulseaudio/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+chown root:audio /dev/snd/*
+
+exec /usr/bin/pulseaudio -vvv --log-target=stderr


### PR DESCRIPTION
Add entrypoint script for pulseaudio for graceful shutdown and moves 'chown root:audio /dev/snd/*' from helm chart cmd args to pa entrypoint, use exec to ensure pulseaudio is pid1 (re #2422)