### PR TITLE
[bot] abort early on searching for acestors

### DIFF
--- a/src/staging/bot.py
+++ b/src/staging/bot.py
@@ -1352,6 +1352,19 @@ updates:
         ancestor_commit = repo.commit(ancestor_ref)
         child_commit = repo.commit(child_ref)
 
+        try:
+            Git(".").merge_base(
+                ancestor_commit.hexsha, child_commit.hexsha, is_ancestor=True
+            )
+        except git.GitCommandError as exc:
+            # git failing with status 1 indicates that ancestor is not an
+            # ancestor of child
+            # => we can exit early
+            # The only other exit code is 128, which indicates that the commit
+            # hexsha is unknown, which must not happen
+            assert exc.status == 1
+            return None
+
         def _recurse_search_for_ancestor(
             commit: git.Commit, ancestor: git.Commit
         ) -> list[git.Commit] | None:


### PR DESCRIPTION
Currently the recursive search for commits needlessly searches the full history if the "ancestor" is not actually an ancestor. We can check this easier using `git merge-base --is-ancestor $ancestor $child` and abort early if we `$ancestor` is not an actual ancestor.

This fixes the "hanging" action in https://github.com/SUSE/BCI-dockerfile-generator/actions/runs/14708126618