### PR TITLE
[bot] Return early when child == ancestor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # need the full history for the unit tests
+          fetch-depth: 0
+
       - uses: actions/cache@v4
         with:
           path: ~/.tox
           key: tox-${{ matrix.python_version }}-${{ hashFiles('poetry.lock') }}
+
+      - name: fix the file permissions of the repository
+        run: chown -R $(id -un):$(id -gn) .
 
       - run: |
           poetry install

--- a/src/staging/git_repo.py
+++ b/src/staging/git_repo.py
@@ -1,0 +1,45 @@
+"""Module containing helper functions interact with git repositories."""
+
+import git
+
+
+def get_commit_range_between_refs(
+    child_ref: str, ancestor_ref: str, repo_path: str = "."
+) -> set[git.Commit] | None:
+    """Returns all commits leading from ``child_ref`` to ``ancestor_ref``,
+    **excluding** ``ancestor_ref`` in the repository specified via `repo_path`.
+
+    If ``ancestor_ref`` is not an ancestor of ``child_ref``, then ``None`` is
+    returned. If ``ancestor_ref`` and ``child_ref`` are the same commit (can be
+    denoted via different names), then an empty set is returned.
+
+    """
+    repo = git.Repo(repo_path)
+
+    def is_ancestor(child_sha: str, ancestor_sha: str) -> bool:
+        """Checks whether the commit identified via ``ancestor_sha`` is an
+        ancestor of the commit identified via ``child_sha``.
+
+        """
+        try:
+            repo.git.merge_base(ancestor_sha, child_sha, is_ancestor=True)
+            return True
+        except git.GitCommandError as exc:
+            # git failing with status 1 indicates that ancestor is not an
+            # ancestor of child
+            # The only other exit code is 128, which indicates that the commit
+            # hexsha is unknown, which must not happen
+            assert exc.status == 1
+            return False
+
+    ancestor_commit = repo.commit(ancestor_ref)
+    child_commit = repo.commit(child_ref)
+
+    if not is_ancestor(child_commit.hexsha, ancestor_commit.hexsha):
+        return None
+
+    commit_hexshas = repo.git.rev_list(
+        child_commit.hexsha, f"^{ancestor_commit.hexsha}"
+    ).splitlines()
+
+    return {repo.commit(sha) for sha in commit_hexshas}

--- a/tests/test_git_repo.py
+++ b/tests/test_git_repo.py
@@ -1,0 +1,81 @@
+import git
+import pytest
+from pytest import Config
+
+from staging.git_repo import get_commit_range_between_refs
+
+
+@pytest.mark.parametrize(
+    "child_ref, ancestor_ref, expected_commit_range",
+    [
+        (
+            "1bcd993b0a8782e1756725127c0cbb6d8c88845e",
+            "1bcd993b0a8782e1756725127c0cbb6d8c88845e",
+            {},
+        ),
+        # 04d1acf7246e8ba11a2c454dc200ce58b53cb807 is the child of 1bcd993b0a8782e1756725127c0cbb6d8c88845e
+        (
+            "1bcd993b0a8782e1756725127c0cbb6d8c88845e",
+            "04d1acf7246e8ba11a2c454dc200ce58b53cb807",
+            {"1bcd993b0a8782e1756725127c0cbb6d8c88845e"},
+        ),
+        # above case, wrong way around: child is the ancestor
+        (
+            "04d1acf7246e8ba11a2c454dc200ce58b53cb807",
+            "1bcd993b0a8782e1756725127c0cbb6d8c88845e",
+            None,
+        ),
+        # A more involved test case:
+        #
+        # * |   19c42351 Merge pull request #2442 from HVSharma12/pulseaudio-entrypoint
+        # |\ \
+        # | * | 43074689 Add entrypoint script for PulseAudio container
+        # * | |   e57be2ad Merge pull request #2444 from SUSE/poetry_lock_update
+        # |\ \ \
+        # | * | | 9ed4c2d9 Update poetry.lock
+        # * | | |   9ede9a87 Merge pull request #2439 from SUSE/drop_gcc12
+        # |\ \ \ \
+        # | |/ / /
+        # |/| | |
+        # | * | | fe656acb Remove gcc 12 container
+        # | |/ /
+        # * | |   86990f63 Merge pull request #2441 from SUSE/cosign
+        # |\ \ \
+        # | |/ /
+        # |/| |
+        # | * | 1aa8fc9f update cosign versions
+        # |/ /
+        # * |   37ebaf51 Merge pull request #2435 from HVSharma12/firefox-audio-fix
+        #
+        (
+            "e57be2ad",
+            "86990f63",
+            {
+                "e57be2ad",
+                "9ede9a87",
+                "9ed4c2d9",
+                "fe656acb",
+            },
+        ),
+    ],
+)
+def test_get_git_commit_range(
+    pytestconfig: Config,
+    child_ref: str,
+    ancestor_ref: str,
+    expected_commit_range: set[str] | None,
+) -> None:
+    repo_path = str(pytestconfig.rootpath.absolute())
+    repo = git.Repo(repo_path)
+
+    if expected_commit_range is None:
+        expected_res = None
+    else:
+        expected_res = {repo.commit(sha) for sha in expected_commit_range}
+        # verify that ancestor_ref is not in the returned set!
+        assert repo.commit(ancestor_ref) not in expected_res
+
+    assert (
+        get_commit_range_between_refs(child_ref, ancestor_ref, repo_path=repo_path)
+        == expected_res
+    )


### PR DESCRIPTION
The `_get_commit_range_between_refs` function, specifically `_recurse_search_for_ancestor` does not terminate if child == ancestor, so we abort early if both commits are the same