### PR TITLE
Pre-create pcpqa & systemd-coredump users with fixed uids

### DIFF
--- a/src/bci_build/package/appcontainers.py
+++ b/src/bci_build/package/appcontainers.py
@@ -86,6 +86,12 @@ COPY pmcd pmlogger /etc/sysconfig/
 # This can be removed after the pcp dependency on sysconfig is removed
 {DOCKERFILE_RUN} systemctl disable wicked wickedd || :
 
+{DOCKERFILE_RUN} useradd --comment "PCP Quality Assurance" \
+    --create-home --home-dir /var/lib/pcp/testsuite \
+    --shell /bin/bash \
+    --uid 496 \
+        pcpqa
+
 HEALTHCHECK --start-period=30s --timeout=20s --interval=10s --retries=3 \
     CMD /usr/local/bin/healthcheck
 """,

--- a/src/bci_build/package/basecontainers.py
+++ b/src/bci_build/package/basecontainers.py
@@ -93,6 +93,8 @@ INIT_CONTAINERS = [
                 && printf "[Manager]\\nLogColor=no" > \\
                     /etc/systemd/system.conf.d/01-sle-bci-nocolor.conf
             RUN {_DISABLE_GETTY_AT_TTY1_SERVICE}
+            {DOCKERFILE_RUN} useradd --no-create-home --uid 497 systemd-coredump
+
             HEALTHCHECK --interval=5s --timeout=5s --retries=5 CMD ["/usr/bin/systemctl", "is-active", "multi-user.target"]
             """
         ),

--- a/src/bci_build/package/basecontainers.py
+++ b/src/bci_build/package/basecontainers.py
@@ -89,10 +89,10 @@ INIT_CONTAINERS = [
         logo_url="https://opensource.suse.com/bci/SLE_BCI_logomark_green.svg",
         custom_end=textwrap.dedent(
             f"""
-            RUN install -d -m 0755 /etc/systemd/system.conf.d/ \\
+            {DOCKERFILE_RUN} install -d -m 0755 /etc/systemd/system.conf.d/ \\
                 && printf "[Manager]\\nLogColor=no" > \\
                     /etc/systemd/system.conf.d/01-sle-bci-nocolor.conf
-            RUN {_DISABLE_GETTY_AT_TTY1_SERVICE}
+            {DOCKERFILE_RUN} {_DISABLE_GETTY_AT_TTY1_SERVICE}
             {DOCKERFILE_RUN} useradd --no-create-home --uid 497 systemd-coredump
 
             HEALTHCHECK --interval=5s --timeout=5s --retries=5 CMD ["/usr/bin/systemctl", "is-active", "multi-user.target"]


### PR DESCRIPTION
These users get created by systemd-sysusers on container start and their uid is not fixed. To prevent that, we pre-create these users