### PR TITLE
Make the cosign image singleton

### DIFF
--- a/src/bci_build/package/cosign.py
+++ b/src/bci_build/package/cosign.py
@@ -18,6 +18,7 @@ COSIGN_CONTAINERS = [
         custom_description="Signing OCI containers using Sigstore, {based_on_container}.",
         os_version=os_version,
         is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
+        is_singleton_image=True,
         from_target_image=generate_from_image_tag(os_version, "bci-micro"),
         version="%%cosign_version%%",
         tag_version=format_version(


### PR DESCRIPTION
This way we don't have to constantly update the aggregation on version updates.