### PR TITLE
Mark the kiosk containers as singleton images

### DIFF
--- a/src/bci_build/package/firefox.py
+++ b/src/bci_build/package/firefox.py
@@ -17,6 +17,8 @@ FIREFOX_CONTAINERS = [
         is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
         exclusive_arch=KIOSK_EXCLUSIVE_ARCH,
         version=(ff_ver_re := "%%ff_ver%%"),
+        tag_version=None if os_version.is_tumbleweed else "esr",
+        is_singleton_image=True,
         version_in_uid=False,
         pretty_name="Mozilla Firefox",
         package_list=(

--- a/src/bci_build/package/pulseaudio.py
+++ b/src/bci_build/package/pulseaudio.py
@@ -31,6 +31,7 @@ PULSEAUDIO_CONTAINERS = [
         version_in_uid=False,
         exclusive_arch=KIOSK_EXCLUSIVE_ARCH,
         is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
+        is_singleton_image=True,
         version=(pulseaudio_ver_re := "%%pulseaudio_ver%%"),
         pretty_name="Pulseaudio",
         package_list=["pulseaudio", "pulseaudio-utils"],

--- a/src/bci_build/package/xorg.py
+++ b/src/bci_build/package/xorg.py
@@ -31,6 +31,7 @@ XORG_CONTAINERS = [
         version_in_uid=False,
         tag_version=(tag_ver := "21"),
         is_latest=os_version in CAN_BE_LATEST_OS_VERSION,
+        is_singleton_image=True,
         version=(xorg_server_re := "%%xorg_server_ver%%"),
         pretty_name="Xorg Server",
         package_list=[


### PR DESCRIPTION
Also set "esr" as a rolling tag rather than a package suffix.