### PR TITLE
restore executable permissions on bind entrypoint

### DIFF
--- a/src/bci_build/package/bind.py
+++ b/src/bci_build/package/bind.py
@@ -67,6 +67,7 @@ BIND_CONTAINERS = [
             """),
         custom_end=textwrap.dedent(rf"""
             COPY entrypoint.sh {(_entrypoint := "/usr/local/bin/entrypoint.sh")}
+            {DOCKERFILE_RUN} chmod +x {_entrypoint}
 
             # create directories that tmpfiles.d would create for us
             {DOCKERFILE_RUN} \


### PR DESCRIPTION
For reasons beyond me this worked locally but not in the build service *shrug*.