### PR TITLE
Pin all third-party github actions using SHA1 hashes + comment out pip handling for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"
+# Supposedly dependabot breaks when using Poetry 2.
+#  - package-ecosystem: "pip"
+#    directory: "/"
+#    schedule:
+#      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
       - run: touch ./build/.nojekyll
 
       - name: deploy to github pages
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8 # v4
         with:
           branch: gh-pages
           folder: build

--- a/.github/workflows/cleanup-staging.yml
+++ b/.github/workflows/cleanup-staging.yml
@@ -40,7 +40,7 @@ jobs:
         run: poetry install
 
       - name: find last comment made by the bot
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
         id: find_comment
         with:
           issue-number: ${{ github.event.number }}

--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Slash Command Dispatch
-        uses: peter-evans/slash-command-dispatch@v4
+        uses: peter-evans/slash-command-dispatch@13bc09769d122a64f75aa5037256f6f2d78be8c4 # v4
         with:
           token: ${{ secrets.PAT }}
           commands: |

--- a/.github/workflows/help-command.yml
+++ b/.github/workflows/help-command.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}

--- a/.github/workflows/obs_build.yml
+++ b/.github/workflows/obs_build.yml
@@ -37,7 +37,7 @@ jobs:
         run: poetry install
 
       - name: find the previous comment created by the bot
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
         id: find_comment
         with:
           issue-number: ${{ github.event.number }}
@@ -53,7 +53,7 @@ jobs:
         if: steps.find_comment.outputs.comment-id != ''
 
       - name: update the comment with the previous build explaining that it has been deleted
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
@@ -97,7 +97,7 @@ jobs:
 
       - name: create a comment with a link to the staging project
         if: env.no_change != 'true'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         id: create_comment
         with:
           comment-id: ${{ steps.find_comment.outputs.comment-id || '' }}
@@ -116,7 +116,7 @@ jobs:
         if: env.no_change != 'true'
 
       - name: Install crane to list images on the registry
-        uses: imjasonh/setup-crane@v0.4
+        uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
         if: env.no_change != 'true'
 
       - name: retrieve the build result
@@ -149,7 +149,7 @@ jobs:
 
       - name: report the finished build
         if: env.no_change != 'true'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-id: ${{ steps.create_comment.outputs.comment-id }}

--- a/.github/workflows/update-deployment-branches.yml
+++ b/.github/workflows/update-deployment-branches.yml
@@ -76,7 +76,7 @@ jobs:
           OSC_PASSWORD: ${{ secrets.OSC_PASSWORD }}
 
       - name: create a pull request
-        uses: vsoch/pull-request-action@master
+        uses: vsoch/pull-request-action@77b3eea5c721545c56f775e1ed4ff9c9c1386148 # master
         id: create-pr
         env:
           GITHUB_TOKEN: ${{ secrets.CHECKOUT_TOKEN }}

--- a/.github/workflows/update-versions-and-files.yml
+++ b/.github/workflows/update-versions-and-files.yml
@@ -32,7 +32,7 @@ jobs:
         run: ./update-files.sh
 
       - name: create a pull request with the updated versions and files
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
         with:
           token: ${{ secrets.CHECKOUT_TOKEN }}
           delete-branch: true

--- a/.github/workflows/vc-command.yml
+++ b/.github/workflows/vc-command.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Add reaction to the original comment on success
         if: ${{ success() }}
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:
           token: ${{ secrets.PAT }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
@@ -69,7 +69,7 @@ jobs:
 
       - name: Add reaction and a link to the error to the original comment on failure
         if: ${{ failure() || cancelled() }}
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:
           token: ${{ secrets.PAT }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}


### PR DESCRIPTION
As per official GitHub security recommendations.