### PR TITLE
Remove redundant permission command

### DIFF
--- a/src/bci_build/package/rmt-server/entrypoint.sh
+++ b/src/bci_build/package/rmt-server/entrypoint.sh
@@ -1,14 +1,6 @@
 #!/bin/bash
 set -e
 
-# PV could be empty, make sure the directories exist
-mkdir -p /var/lib/rmt/public/repo
-mkdir -p /var/lib/rmt/public/suma
-mkdir -p /var/lib/rmt/regsharing
-mkdir -p /var/lib/rmt/tmp
-# Set permissions
-chown -R _rmt:nginx /var/lib/rmt
-
 if [ -z "${MYSQL_HOST}" ]; then
 	echo "MYSQL_HOST not set!"
 	exit 1


### PR DESCRIPTION
This PR will remove script adding user permisson to `/var/lib/rmt`. This is done through the rpm spec script.