### PR TITLE
Revert "Remove redundant permission command"

### DIFF
--- a/src/bci_build/package/rmt-server/entrypoint.sh
+++ b/src/bci_build/package/rmt-server/entrypoint.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -e
 
+# PV could be empty, make sure the directories exist
+mkdir -p /var/lib/rmt/public/repo
+mkdir -p /var/lib/rmt/public/suma
+mkdir -p /var/lib/rmt/regsharing
+mkdir -p /var/lib/rmt/tmp
+# Set permissions
+chown -R _rmt:nginx /var/lib/rmt
+
 if [ -z "${MYSQL_HOST}" ]; then
 	echo "MYSQL_HOST not set!"
 	exit 1

--- a/src/bci_build/package/rmt-server/entrypoint.sh
+++ b/src/bci_build/package/rmt-server/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-# PV could be empty, make sure the directories exist
+# Persistent Volume mount (PV) could be empty, make sure the directories exist
 install -d -m 0755 -o _rmt -g nginx /var/lib/rmt
 install -d -m 0755 -o _rmt -g nginx /var/lib/rmt/public/repo
 install -d -m 0755 -o _rmt -g nginx /var/lib/rmt/public/suma

--- a/src/bci_build/package/rmt-server/entrypoint.sh
+++ b/src/bci_build/package/rmt-server/entrypoint.sh
@@ -2,12 +2,11 @@
 set -e
 
 # PV could be empty, make sure the directories exist
-mkdir -p /var/lib/rmt/public/repo
-mkdir -p /var/lib/rmt/public/suma
-mkdir -p /var/lib/rmt/regsharing
-mkdir -p /var/lib/rmt/tmp
-# Set permissions
-chown -R _rmt:nginx /var/lib/rmt
+install -d -m 0755 -o _rmt -g nginx /var/lib/rmt
+install -d -m 0755 -o _rmt -g nginx /var/lib/rmt/public/repo
+install -d -m 0755 -o _rmt -g nginx /var/lib/rmt/public/suma
+install -d -m 0755 -o _rmt -g nginx /var/lib/rmt/regsharing
+install -d -m 0755 -o _rmt -g nginx /var/lib/rmt/tmp
 
 if [ -z "${MYSQL_HOST}" ]; then
 	echo "MYSQL_HOST not set!"


### PR DESCRIPTION
The comment was giving a hint. these files and permissions are not set by the rpm script because they come via a volume mount from helm (hence are not initialized from the container like with a podman mount)

Reverts SUSE/BCI-dockerfile-generator#2572