### PR TITLE
Fix Firefox profile loading issue

### DIFF
--- a/src/bci_build/package/firefox.py
+++ b/src/bci_build/package/firefox.py
@@ -61,7 +61,12 @@ FIREFOX_CONTAINERS = [
         supported_until=KIOSK_SUPPORT_ENDS,
         cmd=["/bin/bash", "-c", "firefox --kiosk $URL"],
         # TODO add package_version_check and tag_version
-        build_stage_custom_end=f"{DOCKERFILE_RUN} useradd -m user -u 1000",
+        # Ensure that the user is created and Firefox has access to its profile directory.
+        build_stage_custom_end=textwrap.dedent(f"""\
+            {DOCKERFILE_RUN} useradd -m -u 1000 -U user
+            {DOCKERFILE_RUN} mkdir -p /home/user/.mozilla/firefox
+            {DOCKERFILE_RUN} chown -R user:user /home/user/.mozilla
+            """),
         custom_end=textwrap.dedent("""
             ENV DISPLAY=":0"
             COPY --from=builder /etc/passwd /etc/passwd


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0c61d66a-ccc9-4f57-b957-6bef9b7eb53a)

This was caused by the .mozilla/firefox directory not being created with the correct ownership in the final image. Although the user was created and its home directory copied from the builder stage, the Firefox profile directory did not exist/lacked write permission for the user.

Changes made:
- Added a `RUN mkdir -p /home/user/.mozilla/firefox` 
- Applied `chown -R user:user` to ensure proper ownership