### PR TITLE
add noto-sans-cjk-fonts to firefox container

### DIFF
--- a/src/bci_build/package/firefox.py
+++ b/src/bci_build/package/firefox.py
@@ -37,6 +37,8 @@ FIREFOX_CONTAINERS = [
                 "xorg-x11-fonts",
                 # for puleaudio communication
                 "libpulse0",
+                # for cjk fonts
+                "noto-sans-cjk-fonts",
             ]
             + (
                 ["MozillaFirefox-branding-openSUSE", "libavcodec58_134"]


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/7d7b7f99-a4c2-4608-9863-b576d30cee26)

add noto-sans-cjk-fonts to cover cjk fonts 