### PR TITLE
Replace libavcodec57 with libavcodec58_134 for Firefox container

### DIFF
--- a/src/bci_build/package/firefox.py
+++ b/src/bci_build/package/firefox.py
@@ -43,7 +43,9 @@ FIREFOX_CONTAINERS = [
                 "libavcodec58_134",
             ]
             + (
-                ["MozillaFirefox-branding-openSUSE",]
+                [
+                    "MozillaFirefox-branding-openSUSE",
+                ]
                 if os_version.is_tumbleweed
                 else [
                     "MozillaFirefox-branding-SLE",

--- a/src/bci_build/package/firefox.py
+++ b/src/bci_build/package/firefox.py
@@ -39,16 +39,17 @@ FIREFOX_CONTAINERS = [
                 "libpulse0",
                 # for cjk fonts
                 "noto-sans-cjk-fonts",
+                # Provides necessary codecs for video/audio playback
+                "libavcodec58_134",
             ]
             + (
-                ["MozillaFirefox-branding-openSUSE", "libavcodec58_134"]
+                ["MozillaFirefox-branding-openSUSE",]
                 if os_version.is_tumbleweed
                 else [
                     "MozillaFirefox-branding-SLE",
                     # required by Firefox via /usr/bin/gconftool-2
                     # to be fixed via FileProvides
                     "gconf2",
-                    "libavcodec57",
                 ]
             )
         ),


### PR DESCRIPTION
Replaces libavcodec57 with libavcodec58_134 in Firefox kiosk container to enable video playback support on SLE, matching functionality available in openSUSE Leap builds.

Resolves video stream playback issues (e.g., YouTube).