### PR TITLE
Revert ".github/dependabot.yml: Comment out pip handling for now"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-# Supposedly dependabot breaks when using Poetry 2.
-#  - package-ecosystem: "pip"
-#    directory: "/"
-#    schedule:
-#      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Poetry v2 support has been added to dependabot now.

This reverts commit c11a4510e3731e3577c230cf206652d453d14877.