### PR TITLE
setup permissions on the db mount point

### DIFF
--- a/src/bci_build/package/mariadb.py
+++ b/src/bci_build/package/mariadb.py
@@ -143,6 +143,7 @@ COPY idexec /usr/local/bin/idexec
 {DOCKERFILE_RUN} sed -i -e 's|^\(bind-address.*\)|#\1|g' /etc/my.cnf
 
 {DOCKERFILE_RUN} install -d -m 0755 -o mysql -g mysql /run/mysql
+{DOCKERFILE_RUN} install -d -m 0700 -o mysql -g root /var/lib/mysql
 """,
         )
     )


### PR DESCRIPTION
This is needed for being able to run the container as non-root.