### PR TITLE
Restore the mariadb containers that are SP6 based

### DIFF
--- a/src/bci_build/package/mariadb.py
+++ b/src/bci_build/package/mariadb.py
@@ -7,8 +7,8 @@ from bci_build.container_attributes import TCP
 from bci_build.container_attributes import Arch
 from bci_build.container_attributes import BuildType
 from bci_build.container_attributes import SupportLevel
-from bci_build.os_version import ALL_NONBASE_OS_VERSIONS
 from bci_build.os_version import CAN_BE_LATEST_OS_VERSION
+from bci_build.os_version import OsVersion
 from bci_build.package import DOCKERFILE_RUN
 from bci_build.package import ApplicationStackContainer
 from bci_build.package import ParseVersion
@@ -34,7 +34,7 @@ exec setpriv --pdeathsig=keep --reuid="$u" --regid="$u" --clear-groups -- "$@"
 MARIADB_CONTAINERS = []
 MARIADB_CLIENT_CONTAINERS = []
 
-for os_version in ALL_NONBASE_OS_VERSIONS:
+for os_version in (OsVersion.SP6, OsVersion.SP7, OsVersion.TUMBLEWEED):
     mariadb_version = get_pkg_version("mariadb", os_version)
 
     pkg_prefix = ""


### PR DESCRIPTION
The condition here was deleting the SP6 containers, which are however still supported until end of overlap support.