### PR TITLE
drop /var/cache/ldconfig/aux-cache from container images

### DIFF
--- a/src/bci_build/package/base.py
+++ b/src/bci_build/package/base.py
@@ -77,8 +77,11 @@ rm -rf /var/cache/zypp/*
 # drop timestamp
 tail -n +2 /var/lib/zypp/AutoInstalled > /var/lib/zypp/AutoInstalled.new && mv /var/lib/zypp/AutoInstalled.new /var/lib/zypp/AutoInstalled
 
+# drop useless device/inode specific cache file (see https://github.com/docker-library/official-images/issues/16044)
+rm -v /var/cache/ldconfig/aux-cache
+
 # remove backup of /etc/shadow
-rm -f /etc/shadow-
+rm -vf /etc/shadow-
 
 {% if os_version.is_tumbleweed -%}
 # Assign a fixed architecture in zypp.conf, to use the container's arch even if

--- a/src/bci_build/package/basecontainers.py
+++ b/src/bci_build/package/basecontainers.py
@@ -62,14 +62,16 @@ MICRO_CONTAINERS = [
                 if os_version.is_sle15
                 else ""
             )
-            + textwrap.dedent(
-                f"""
-            # not making sense in a zypper-free image
-            {DOCKERFILE_RUN} rm -v /target/var/lib/zypp/AutoInstalled
+            + textwrap.dedent(f"""
             {DOCKERFILE_RUN} zypper -n install jdupes \\
-                && jdupes -1 -L -r /target/usr/"""
-            )
+                && jdupes -1 -L -r /target/usr/""")
         ),
+        custom_end=textwrap.dedent(f"""
+            # not making sense in a zypper-free image
+            {DOCKERFILE_RUN} rm -v /var/lib/zypp/AutoInstalled
+            # includes device and inode numbers that change on deploy
+            {DOCKERFILE_RUN} rm -v /var/cache/ldconfig/aux-cache
+        """),
     )
     for os_version in ALL_BASE_OS_VERSIONS
 ]
@@ -341,6 +343,9 @@ MINIMAL_CONTAINERS = [
             # not making sense in a zypper-free image
             rm -v /var/lib/zypp/AutoInstalled
 
+            # includes device and inode numbers that change on deploy
+            rm -v /var/cache/ldconfig/aux-cache
+
             # Will be recreated by the next rpm(1) run as root user
             rm -v /usr/lib/sysimage/rpm/Index.db
             """
@@ -379,6 +384,9 @@ BUSYBOX_CONTAINERS = [
 
             # not making sense in a zypper-free image
             rm -v /var/lib/zypp/AutoInstalled
+
+            # includes device and inode numbers that change on deploy
+            rm -v /var/cache/ldconfig/aux-cache
 
             # Will be recreated by the next rpm(1) run as root user
             rm -v /usr/lib/sysimage/rpm/Index.db


### PR DESCRIPTION
This not only doesn't make them reproducible, it is including file attributes like device number, inode number and inode change time. This means it is not only unreproducible, but completely useless at boot time since the device and inode numbers of libraries will be different.