### PR TITLE
Always use zypper clean -a

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -599,7 +599,7 @@ fi
 # Clean up after zypper if it is present
 #---------------------------------------
 if command -v zypper > /dev/null; then
-    zypper -n clean
+    zypper -n clean -a
 fi
 
 {LOG_CLEAN}

--- a/src/bci_build/package/base/README.md.j2
+++ b/src/bci_build/package/base/README.md.j2
@@ -28,7 +28,7 @@ FROM {{ image.pretty_reference }}
 RUN set -euo pipefail; \
     zypper -n ref; \
     zypper -n in skopeo; \
-    zypper -n clean; \
+    zypper -n clean -a ; \
     rm -rf /var/log/{lastlog,tallylog,zypper.log,zypp/history,YaST2}
 ```
 

--- a/src/bci_build/package/golang.py
+++ b/src/bci_build/package/golang.py
@@ -70,7 +70,7 @@ def _get_golang_kwargs(
             f"""
             # only available on go's tsan_arch architectures
             #!ArchExclusiveLine: x86_64 aarch64 s390x ppc64le
-            {DOCKERFILE_RUN} if zypper -n install {go}-race; then zypper -n clean; fi
+            {DOCKERFILE_RUN} if zypper -n install {go}-race; then zypper -n clean -a; fi
             {DOCKERFILE_RUN} install -m 755 -d /go/bin /go/src
             {DOCKERFILE_RUN} {LOG_CLEAN}
             WORKDIR /go


### PR DESCRIPTION
This removes the cached repositories as well, which will be almost always out of date anyway when the container is used.