### PR TITLE
Set GF_PATHS_CONFIG variable (bsc#1248221)

### DIFF
--- a/src/bci_build/package/grafana.py
+++ b/src/bci_build/package/grafana.py
@@ -35,6 +35,7 @@ GRAFANA_CONTAINERS = [
         entrypoint=["/run.sh"],
         extra_files=_GRAFANA_FILES,
         env={
+            "GF_PATHS_CONFIG": "/etc/grafana/grafana.ini",
             "GF_PATHS_DATA": "/var/lib/grafana",
             "GF_PATHS_HOME": "/usr/share/grafana",
             "GF_PATHS_LOGS": "/var/log/grafana",


### PR DESCRIPTION
This environment variables is defined in https://grafana.com/docs/grafana/latest/setup-grafana/configure-docker/#default-paths.