### PR TITLE
Adding xdotool to xorg container

### DIFF
--- a/src/bci_build/package/xorg.py
+++ b/src/bci_build/package/xorg.py
@@ -57,6 +57,8 @@ XORG_CONTAINERS = [
                 "xf86-input-libinput",
                 "xkeyboard-config",
                 "xinput",
+                # to allow for custom automations in initrc
+                "xdotool",
                 # indirect dependencies
                 "xorg-x11-essentials",
                 "xdm",


### PR DESCRIPTION
This allows for customers to automate any setup that's needed in the xinitrc file. The specific need that prompted this is a need to enable NumLock on a system that doesn't have the physical button. 