### PR TITLE
Remove the SLmicro 6.0 base container

### DIFF
--- a/src/bci_build/package/basecontainers.py
+++ b/src/bci_build/package/basecontainers.py
@@ -446,57 +446,6 @@ for os_version in ALL_OS_VERSIONS - {OsVersion.TUMBLEWEED}:
     )
 
 
-# SL Micro 6.0 GA kernel container devel
-_SLM60_BASEURL = "https://api.opensuse.org/public/build/SUSE:ALP:Source:Standard:Core:1.0:Build/standard/"
-_SLM60_KERNEL_PACKAGES = [
-    "x86_64/patchinfo.ga/kernel-devel-6.4.0-17.1.noarch.rpm",
-    "x86_64/patchinfo.ga/kernel-macros-6.4.0-17.1.noarch.rpm",
-    "x86_64/patchinfo.ga/kernel-syms-6.4.0-17.1.x86_64.rpm",
-    "x86_64/patchinfo.ga/kernel-default-devel-6.4.0-17.1.x86_64.rpm",
-    "aarch64/patchinfo.ga/kernel-syms-6.4.0-17.1.aarch64.rpm",
-    "aarch64/patchinfo.ga/kernel-default-devel-6.4.0-17.1.aarch64.rpm",
-    "aarch64/patchinfo.ga/kernel-64kb-devel-6.4.0-17.1.aarch64.rpm",
-    "s390x/patchinfo.ga/kernel-syms-6.4.0-17.1.s390x.rpm",
-    "s390x/patchinfo.ga/kernel-default-devel-6.4.0-17.1.s390x.rpm",
-]
-_SLFO_KEY_ID = "09d9ea69"
-KERNEL_MODULE_CONTAINERS.append(
-    OsContainer(
-        name="slm60-kernel-module-devel",
-        pretty_name="SUSE Linux Micro 6.0 Kernel module development",
-        logo_url="https://opensource.suse.com/bci/SLE_BCI_logomark_green.svg",
-        os_version=OsVersion.SL16_0,
-        supported_until=datetime.date(2028, 6, 30),
-        is_latest=True,
-        package_list=(
-            [
-                "gcc-build",
-                "kmod",
-                "make",
-                "patch",
-                "gawk",
-                "pesign-obs-integration",
-                "dwarves",
-                "libelf-devel",
-                *OsVersion.SL16_0.release_package_names,
-            ]
-        ),
-        exclusive_arch=[Arch.X86_64, Arch.S390X, Arch.AARCH64],
-        extra_files={"_constraints": generate_disk_size_constraints(8)},
-        custom_end=_get_asset_script(_SLM60_BASEURL, _SLM60_KERNEL_PACKAGES)
-        + textwrap.dedent(
-            f"""
-            {DOCKERFILE_RUN} \\
-                [ $(LC_ALL=C rpm --checksig -v *rpm | \\
-                    grep -c -E "^ *V3.*key ID {_SLFO_KEY_ID}:") = {len(_SLM60_KERNEL_PACKAGES)} ] \\
-                && rpm -Uvh --oldpackage --force *.$(uname -m).rpm *.noarch.rpm \\
-                && rm -vf *.rpm \\
-                && rpmqpack | grep -E '^kernel-' | xargs zypper -n addlock\n"""
-        ),
-    )
-)
-
-
 OSC_CHECKOUT = (Path(__file__).parent / "gitea-runner" / "osc_checkout").read_bytes()
 
 GITEA_RUNNER_CONTAINER = OsContainer(


### PR DESCRIPTION
nobody ever implemented testing for it, and now it is kinda dead.