### PR TITLE
Set the min_release_counter for SL 16.0

### DIFF
--- a/src/bci_build/package/basecontainers.py
+++ b/src/bci_build/package/basecontainers.py
@@ -57,6 +57,7 @@ MICRO_CONTAINERS = [
         package_list=[pkg.name for pkg in _get_micro_package_list(os_version)],
         min_release_counter={
             OsVersion.SP7: 41,  # be newer than the newest kiwi based image on SP6
+            OsVersion.SL16_0: 6,
         },
         build_stage_custom_end=(
             (
@@ -91,6 +92,7 @@ INIT_CONTAINERS = [
         package_list=["systemd", "gzip", *os_version.release_package_names],
         min_release_counter={
             OsVersion.SP7: 40,
+            OsVersion.SL16_0: 4,
         },
         is_singleton_image=(
             # preserve backwards compatibility on already released distributions
@@ -247,6 +249,7 @@ def _get_fips_base_kwargs(os_version: OsVersion) -> dict:
         "custom_end": _get_fips_base_custom_end(os_version) + _get_fips_custom_env(),
         "min_release_counter": {
             OsVersion.SP6: 30,
+            OsVersion.SL16_0: 4,
         },
     }
 
@@ -283,6 +286,9 @@ FIPS_MICRO_CONTAINERS = [
                 && jdupes -1 -L -r /target/usr/"""
         ),
         custom_end=_get_fips_custom_env(),
+        min_release_counter={
+            OsVersion.SL16_0: 5,
+        },
     )
     for os_version in ALL_BASE_OS_VERSIONS
 ]
@@ -416,6 +422,7 @@ for os_version in ALL_OS_VERSIONS - {OsVersion.TUMBLEWEED}:
             os_version=os_version,
             min_release_counter={
                 OsVersion.SP7: 40,
+                OsVersion.SL16_0: 17,
             },
             supported_until=_SUPPORTED_UNTIL_SLE.get(os_version),
             is_latest=os_version in CAN_BE_LATEST_BASE_OS_VERSION,

--- a/src/bci_build/package/kiwi.py
+++ b/src/bci_build/package/kiwi.py
@@ -84,6 +84,7 @@ KIWI_CONTAINERS = [
         build_recipe_type=BuildType.DOCKER,
         min_release_counter={
             OsVersion.SP7: 15,
+            OsVersion.SL16_0: 9,
         },
         extra_labels={
             "usage": "This container requires an openSUSE/SUSE host kernel for full functionality.",
@@ -93,5 +94,5 @@ KIWI_CONTAINERS = [
             "_constraints": generate_disk_size_constraints(8)
         },
     )
-    for os_version in list(set(ALL_NONBASE_OS_VERSIONS) | {OsVersion.SL16_0})
+    for os_version in list(set(ALL_NONBASE_OS_VERSIONS))
 ]


### PR DESCRIPTION
This is needed to migrate the project and keep the current counters in sync.