### PR TITLE
Drop unused RMT images

### DIFF
--- a/src/bci_build/package/rmt-mariadb-client/README.md.j2
+++ b/src/bci_build/package/rmt-mariadb-client/README.md.j2
@@ -1,1 +1,0 @@
-../mariadb-client/README.md.j2

--- a/src/bci_build/package/rmt-mariadb/README.md.j2
+++ b/src/bci_build/package/rmt-mariadb/README.md.j2
@@ -1,1 +1,0 @@
-../mariadb/README.md.j2

--- a/src/bci_build/package/rmt-nginx/README.md.j2
+++ b/src/bci_build/package/rmt-nginx/README.md.j2
@@ -1,1 +1,0 @@
-../nginx/README.md.j2


### PR DESCRIPTION
The rmt helm chart switched to use the generic nginx and mariadb images over a year ago:

https://github.com/SUSE/helm-charts/pull/5/
https://github.com/SUSE/helm-charts/commit/f1c0ea63bc69a668d31196bcf9b2f5a2181a7398