### PR TITLE
Run nginx as a non root user

### DIFF
--- a/src/bci_build/package/appcontainers.py
+++ b/src/bci_build/package/appcontainers.py
@@ -278,8 +278,11 @@ def _get_nginx_kwargs(os_version: OsVersion):
         "build_recipe_type": BuildType.DOCKER,
         "extra_files": _NGINX_FILES,
         "support_level": SupportLevel.L3,
-        "exposes_ports": [TCP(80)],
+        "exposes_ports": [TCP(8080)],
         "custom_end": f"""{version_check_lines}
+# Modify the default Nginx config to listen on port 8080 and PID file location to a writable path
+{DOCKERFILE_RUN} sed -i 's/listen  *80;/listen 8080;/g' /etc/nginx/nginx.conf &&\\
+    sed -i 's|#pid /run/nginx.pid;|pid /tmp/nginx.pid;|' /etc/nginx/nginx.conf
 {DOCKERFILE_RUN} mkdir /docker-entrypoint.d
 COPY [1-3]0-*.sh /docker-entrypoint.d/
 COPY docker-entrypoint.sh /usr/local/bin


### PR DESCRIPTION
Nginx can be run as non-root user(nginx user) as follows:
```
 podman run -it -p 8080:8080 -u 499:498 <nginx_bci_image>
 ```
where 499 and 498 are the UID and GID of nginx user.
