### PR TITLE
Switch to kernel-default-devel to avoid kernel-syms

### DIFF
--- a/src/bci_build/package/basecontainers.py
+++ b/src/bci_build/package/basecontainers.py
@@ -443,11 +443,17 @@ for os_version in ALL_OS_VERSIONS - {OsVersion.TUMBLEWEED}:
                 + (["tar"] if os_version == OsVersion.SP4 else [])
                 + (["suse-module-tools-scriptlets"] if os_version.is_sl16 else [])
             ),
-            custom_end=textwrap.dedent(f"""
+            custom_end=textwrap.dedent(
+                (
+                    ""
+                    if os_version.is_sl16
+                    else f"""
                 #!ArchExclusiveLine: x86_64 aarch64
                 {DOCKERFILE_RUN} if zypper -n install mokutil; then zypper -n clean -a; fi
                 {DOCKERFILE_RUN} {LOG_CLEAN}
-            """),
+            """
+                )
+            ),
             extra_files={"_constraints": generate_disk_size_constraints(8)},
         )
     )


### PR DESCRIPTION
kernel-syms is just a compat package that merely depends on kernel-devel/kernel-default-devel and no longer part of SL16.