### PR TITLE
Revert "Skip pgvector for 18, not available"

### DIFF
--- a/src/bci_build/package/postgres.py
+++ b/src/bci_build/package/postgres.py
@@ -46,7 +46,7 @@ POSTGRES_CONTAINERS = [
             [
                 f"postgresql{ver}-pgvector",
             ]
-            if os_version.is_tumbleweed and ver != 18
+            if os_version.is_tumbleweed
             else []
         ),
         version="%%pg_patch_version%%",


### PR DESCRIPTION
Reverts SUSE/BCI-dockerfile-generator#2968

actually there was a SR in flight that added pgvector. 