### PR TITLE
fix: Include diff in kubectl to make kubectl diff work

### DIFF
--- a/src/bci_build/package/kubectl.py
+++ b/src/bci_build/package/kubectl.py
@@ -61,7 +61,7 @@ KUBECTL_CONTAINERS = [
                 parse_version=ParseVersion.PATCH,
             )
         ],
-        package_list=[f"kubernetes{ver}-client"],
+        package_list=[f"kubernetes{ver}-client", "diffutils"],
         entrypoint=["kubectl"],
         license="Apache-2.0",
         support_level=SupportLevel.L3,


### PR DESCRIPTION
TIL kubectl diff uses "diff" https://kubernetes.io/docs/reference/kubectl/generated/kubectl_diff/ and https://github.com/kubernetes/kubernetes/blob/release-1.33/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go#L134