### PR TITLE
Fix link to the bugzilla project

### DIFF
--- a/src/bci_build/package/templates/licensing_and_eula.j2
+++ b/src/bci_build/package/templates/licensing_and_eula.j2
@@ -12,7 +12,7 @@ This image is based on [openSUSE Tumbleweed](https://get.opensuse.org/tumbleweed
 {% if image.support_level|string == "techpreview" -%}
 This image is a tech preview. Do not use it for production.
 Your feedback is welcome.
-Please report any issues to the [SUSE Bugzilla](https://bugzilla.suse.com/enter_bug.cgi?product=SUSE%20Linux%20Enterprise%20Base%20Container%20Images).
+Please report any issues to the [SUSE Bugzilla](https://bugzilla.suse.com/enter_bug.cgi?product=PUBLIC%20SUSE%20Linux%20Enterprise%20Base%20Container%20Images).
 {% elif image.support_level|string == 'unsupported' -%}
 This image is unsupported and provided as-is.
 {% else -%}


### PR DESCRIPTION
We need to link the PUBLIC one, as the other one is only available to SUSE employees.