### PR TITLE
There is a dependency on 'xzcat' in rails 8.0, so preinstall it in the

### DIFF
--- a/src/bci_build/package/ruby.py
+++ b/src/bci_build/package/ruby.py
@@ -63,6 +63,7 @@ def _get_ruby_kwargs(ruby_version: Literal["2.5", "3.4"], os_version: OsVersion)
             "make",
             # additional dependencies supplementing rails
             "timezone",
+            "xz",
         ]
         + os_version.common_devel_packages,
         "extra_files": {


### PR DESCRIPTION
container