### PR TITLE
Remove workaround for missing default linker setting in rust

### DIFF
--- a/src/bci_build/package/rust.py
+++ b/src/bci_build/package/rust.py
@@ -1,7 +1,6 @@
 """Rust language BCI container"""
 
 import datetime
-import textwrap
 from itertools import product
 
 import packaging.version
@@ -116,15 +115,7 @@ requires:rust{rust_version}
                 package_name=f"cargo{rust_version}",
             ),
         ],
-        custom_end=textwrap.dedent(
-            """
-            # workaround for cc only existing as /usr/bin/gcc-N
-            RUN ln -sf $(ls /usr/bin/gcc-* | grep -P ".*gcc-[[:digit:]]+") ${CC} && ${CC} --version
-            """
-            if os_version.is_sle15
-            else ""
-        )
-        + f"COPY {check_fname} /etc/zypp/systemCheck.d/{check_fname}\n",
+        custom_end=f"COPY {check_fname} /etc/zypp/systemCheck.d/{check_fname}\n",
     )
     for rust_version, os_version in (
         *product(


### PR DESCRIPTION
This is no longer necessary after switching to 1.90/1.91