### PR TITLE
cannot use checkout@v4 together with create-pull-request custom token

### DIFF
--- a/.github/workflows/update-versions-and-files.yml
+++ b/.github/workflows/update-versions-and-files.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update-files:
     runs-on: ubuntu-latest
@@ -34,6 +37,7 @@ jobs:
       - name: create a pull request with the updated versions and files
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
         with:
+          # separate token https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
           token: ${{ secrets.CHECKOUT_TOKEN }}
           delete-branch: true
           commit-message: "🤖: Update package versions and external files"


### PR DESCRIPTION
the remote fails with "duplicate authentication header" then. we probably have to find a better solution for this..