### PR TITLE
Add dummy OBS workflow

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,0 +1,10 @@
+workflow:
+  steps:
+    - rebuild_package:
+        project: home:pushman
+        package: dummy
+  filters:
+    event: pull_request
+    branches:
+      only:
+        - this-is-a-dummy-branch-for-obs


### PR DESCRIPTION
This should prevent OBS from getting 404s on workflow runs that don't have a proper workflow.