### PR TITLE
Drop Python 3.12 for TW as well

### DIFF
--- a/src/bci_build/package/python.py
+++ b/src/bci_build/package/python.py
@@ -137,7 +137,7 @@ PYTHON_3_6_CONTAINERS = (
 )
 
 
-_PYTHON_TW_VERSIONS: tuple[_PYTHON_VERSIONS, ...] = ("3.11", "3.12", "3.13")
+_PYTHON_TW_VERSIONS: tuple[_PYTHON_VERSIONS, ...] = ("3.11", "3.13")
 PYTHON_TW_CONTAINERS = (
     PythonDevelopmentContainer(
         **_get_python_kwargs(pyver, OsVersion.TUMBLEWEED),


### PR DESCRIPTION
It is going to be removed, see

https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/thread/YM4WRY2YHQF6KIMBY36QNSLFWVC7AIMD/