### PR TITLE
Remove hack around broken rust update (bsc#1262022)

### DIFF
--- a/src/bci_build/package/rust.py
+++ b/src/bci_build/package/rust.py
@@ -1,7 +1,6 @@
 """Rust language BCI container"""
 
 import datetime
-import textwrap
 from itertools import product
 
 import packaging.version
@@ -96,8 +95,7 @@ RUST_CONTAINERS = [
         env={
             "RUST_VERSION": "%%RUST_VERSION%%",
             "CARGO_VERSION": "%%CARGO_VERSION%%",
-        }
-        | ({"CC": _RUST_CC_PATH} if os_version.is_sle15 else {}),
+        },
         extra_files={
             # prevent ftbfs on workers with a root partition with 4GB
             "_constraints": generate_disk_size_constraints(6),
@@ -117,15 +115,7 @@ requires:rust{rust_version}
                 package_name=f"cargo{rust_version}",
             ),
         ],
-        custom_end=textwrap.dedent(
-            """
-            # workaround for cc only existing as /usr/bin/gcc-N
-            RUN ln -sf $(ls /usr/bin/gcc-* | grep -P ".*gcc-[[:digit:]]+") ${CC} && ${CC} --version
-            """
-            if os_version.is_sle15
-            else ""
-        )
-        + f"COPY {check_fname} /etc/zypp/systemCheck.d/{check_fname}\n",
+        custom_end=f"COPY {check_fname} /etc/zypp/systemCheck.d/{check_fname}\n",
     )
     for rust_version, os_version in (
         *product(


### PR DESCRIPTION
It is now broken differently, so remove this workaround for now. we can
    not build a new one for the other issue.