### PR TITLE
Stop accessing the third party repo outside prepare_template()

### DIFF
--- a/src/bci_build/package/thirdparty.py
+++ b/src/bci_build/package/thirdparty.py
@@ -127,32 +127,6 @@ class ThirdPartyRepoMixin:
         self.third_party_repos = third_party_repos
         self.third_party_package_list = third_party_package_list
 
-        for repo in self.third_party_repos:
-            if not repo.key:
-                res = requests.get(repo.key_url)
-                res.raise_for_status()
-                repo.key = res.text
-
-            if not repo.repo_name:
-                repo.repo_name = repo.name
-
-            if not repo.repo_filename:
-                repo.repo_filename = f"{repo.name}.repo"
-
-            if not repo.key_filename:
-                repo.key_filename = f"{repo.name}.gpg.key"
-
-            self.extra_files.update(
-                {
-                    f"{repo.name}.gpg.key": repo.key,
-                    f"{repo.name}.repo": REPO_FILE.format(
-                        repo_name=repo.repo_name,
-                        base_url=repo.url,
-                        gpg_key=repo.key_url,
-                    ),
-                }
-            )
-
         self._repo = ThirdPartyRepoParser(self.third_party_repos)
         self._rpms: list[RpmPackage] = []
 
@@ -230,6 +204,32 @@ class ThirdPartyRepoMixin:
         assert len(self.third_party_package_list) > 0, (
             "The `third_party_package_list` is empty"
         )
+
+        for repo in self.third_party_repos:
+            if not repo.key:
+                res = requests.get(repo.key_url)
+                res.raise_for_status()
+                repo.key = res.text
+
+            if not repo.repo_name:
+                repo.repo_name = repo.name
+
+            if not repo.repo_filename:
+                repo.repo_filename = f"{repo.name}.repo"
+
+            if not repo.key_filename:
+                repo.key_filename = f"{repo.name}.gpg.key"
+
+            self.extra_files.update(
+                {
+                    f"{repo.name}.gpg.key": repo.key,
+                    f"{repo.name}.repo": REPO_FILE.format(
+                        repo_name=repo.repo_name,
+                        base_url=repo.url,
+                        gpg_key=repo.key_url,
+                    ),
+                }
+            )
 
         pkgs = self.fetch_rpm_packages()
 

--- a/tests/test_repomdparser.py
+++ b/tests/test_repomdparser.py
@@ -67,28 +67,21 @@ OPENSUSE_REPO_XML = """<?xml version="1.0" encoding="UTF-8"?>
 def fake_repo_get(url, *args, **kwargs):
     resp = Mock()
     resp.raise_for_status.return_value = None
+    resp.status_code = 200
 
-    if url == "https://packages.example.com/sles/15.7/repodata/repomd.xml":
-        resp.content = SLE_REPO_XML
-        resp.status_code = 200
-        return resp
+    match url:
+        case "https://packages.example.com/sles/15.7/repodata/repomd.xml":
+            resp.content = SLE_REPO_XML
+        case "https://packages.example.org/opensuse/15.7/repodata/repomd.xml":
+            resp.content = OPENSUSE_REPO_XML
+        case "https://packages.example.com/sles/15.7/repodata/primary.xml.gz":
+            resp.content = gzip.compress(SLE_PRIMARY_XML.encode("utf-8"))
+        case "https://packages.example.org/opensuse/15.7/repodata/primary.xml.gz":
+            resp.content = gzip.compress(OPENSUSE_PRIMARY_XML.encode("utf-8"))
+        case _:
+            raise ValueError(f"Unexpected URL: {url}")
 
-    if url == "https://packages.example.org/opensuse/15.7/repodata/repomd.xml":
-        resp.content = OPENSUSE_REPO_XML
-        resp.status_code = 200
-        return resp
-
-    if url == "https://packages.example.com/sles/15.7/repodata/primary.xml.gz":
-        resp.content = gzip.compress(SLE_PRIMARY_XML.encode("utf-8"))
-        resp.status_code = 200
-        return resp
-
-    if url == "https://packages.example.org/opensuse/15.7/repodata/primary.xml.gz":
-        resp.content = gzip.compress(OPENSUSE_PRIMARY_XML.encode("utf-8"))
-        resp.status_code = 200
-        return resp
-
-    raise ValueError(f"Unexpected URL: {url}")
+    return resp
 
 
 def test_parse():

--- a/tests/test_thirdparty.py
+++ b/tests/test_thirdparty.py
@@ -14,14 +14,6 @@ class DummyThirdPartyImage(ThirdPartyRepoMixin, DevelopmentContainer):
     pass
 
 
-def fake_key_get(url, *args, **kwargs):
-    resp = Mock()
-    resp.raise_for_status.return_value = None
-    resp.text = "NICE-GPG-KEY"
-    resp.status_code = 200
-    return resp
-
-
 DOCKERFILE_RENDERED_SINGLE = """# SPDX-License-Identifier: MIT
 
 # Copyright
@@ -333,6 +325,7 @@ def test_multiple_third_party_repo_template():
 
 
 def test_third_party_repo():
+    """Test that we can set third_party_repos attribute on initialization and query it."""
     image = DummyThirdPartyImage(
         tag_version="1",
         version="1",
@@ -374,7 +367,26 @@ def test_third_party_repo():
     assert repo.repo_filename == "dummy-third-party-image.repo"
     assert repo.key_filename == "dummy-third-party-image.gpg.key"
 
-    with patch("bci_build.package.thirdparty.requests.get", side_effect=fake_key_get):
+
+def test_third_party_repo_with_prepare():
+    """Test that the GPG key is fetched from configured url."""
+
+    expected_key_url = "https://packages.example.com/keys/repo.asc"
+
+    def mock_request_get(url, *args, **kwargs):
+        if url != expected_key_url:
+            return fake_repo_get(url)
+
+        resp = Mock()
+        resp.raise_for_status.return_value = None
+        resp.text = "NICE-GPG-KEY"
+        resp.status_code = 200
+        return resp
+
+    with patch(
+        "bci_build.package.thirdparty.requests.get",
+        side_effect=mock_request_get,
+    ):
         image = DummyThirdPartyImage(
             tag_version="1",
             version="1",
@@ -389,7 +401,7 @@ def test_third_party_repo():
                 ThirdPartyRepo(
                     name="third-party",
                     url="https://packages.example.com/sles/15.7/",
-                    key_url="https://packages.example.com/keys/repo.asc",
+                    key_url=expected_key_url,
                 ),
             ],
             third_party_package_list=[
@@ -400,13 +412,14 @@ def test_third_party_repo():
                 "dummy-pkg-4",
             ],
         )
+        image.prepare_template()
 
         repo = image.third_party_repos[0]
 
         assert repo.name == "third-party"
         assert repo.url == "https://packages.example.com/sles/15.7/"
         assert repo.key == "NICE-GPG-KEY"
-        assert repo.key_url == "https://packages.example.com/keys/repo.asc"
+        assert repo.key_url == expected_key_url
         assert repo.arch is None
         assert repo.repo_name == "third-party"
         assert repo.repo_filename == "third-party.repo"


### PR DESCRIPTION
We don't want to access multiple 3rd party repositories when not rendering a template.