### PR TITLE
Add amdgpu-dkms-firmware license

### DIFF
--- a/src/bci_build/package/amd.py
+++ b/src/bci_build/package/amd.py
@@ -44,7 +44,8 @@ CUSTOM_END_TEMPLATE = Template(
 # copy firmware to /firmwareDir
 {{ DOCKERFILE_RUN }} \\
     mkdir -p /target/firmwareDir/updates/amdgpu; \\
-    cp -r /lib/firmware/updates/amdgpu /target/firmwareDir/updates/amdgpu
+    cp -r /lib/firmware/updates/amdgpu /target/firmwareDir/updates/amdgpu; \\
+    install -p -D /usr/share/doc/packages/amdgpu-dkms-firmware/LICENSE /target/usr/share/licenses/amdgpu-dkms-firmware/LICENSE
 """
 )
 


### PR DESCRIPTION
The license needs to be included when redistributing the firmware.