### PR TITLE
Add grep to postgres base and contrib

### DIFF
--- a/src/bci_build/package/postgres.py
+++ b/src/bci_build/package/postgres.py
@@ -52,6 +52,7 @@ POSTGRES_CONTAINERS = [
                 f"postgresql{ver}-server",
                 "findutils",
                 "coreutils",
+                "grep",
                 "sed",
                 "tar",
                 "gzip",


### PR DESCRIPTION
This was there when postgres was bci-base based, and removed when switching to micro. hower our users were using it.