### PR TITLE
Prevent key requests outside prepare_template

### DIFF
--- a/src/bci_build/package/nvidia.py
+++ b/src/bci_build/package/nvidia.py
@@ -468,6 +468,8 @@ class NvidiaDriverBCI(ThirdPartyRepoMixin, DevelopmentContainer):
         kernel_packages = [pkg["name"] for pkg in subpackages]
         ignore_in_target_packages = open_packages + closed_packages + kernel_packages
 
+        self.prepare_extra_files()
+
         self.build_stage_custom_end = CUSTOM_END_TEMPLATE.render(
             image=self,
             packages=pkgs,

--- a/src/bci_build/package/thirdparty.py
+++ b/src/bci_build/package/thirdparty.py
@@ -127,32 +127,6 @@ class ThirdPartyRepoMixin:
         self.third_party_repos = third_party_repos
         self.third_party_package_list = third_party_package_list
 
-        for repo in self.third_party_repos:
-            if not repo.key:
-                res = requests.get(repo.key_url)
-                res.raise_for_status()
-                repo.key = res.text
-
-            if not repo.repo_name:
-                repo.repo_name = repo.name
-
-            if not repo.repo_filename:
-                repo.repo_filename = f"{repo.name}.repo"
-
-            if not repo.key_filename:
-                repo.key_filename = f"{repo.name}.gpg.key"
-
-            self.extra_files.update(
-                {
-                    f"{repo.name}.gpg.key": repo.key,
-                    f"{repo.name}.repo": REPO_FILE.format(
-                        repo_name=repo.repo_name,
-                        base_url=repo.url,
-                        gpg_key=repo.key_url,
-                    ),
-                }
-            )
-
         self._repo = ThirdPartyRepoParser(self.third_party_repos)
         self._rpms: list[RpmPackage] = []
 
@@ -222,6 +196,33 @@ class ThirdPartyRepoMixin:
 
         return self._rpms
 
+    def prepare_extra_files(self) -> None:
+        for repo in self.third_party_repos:
+            if not repo.key:
+                res = requests.get(repo.key_url)
+                res.raise_for_status()
+                repo.key = res.text
+
+            if not repo.repo_name:
+                repo.repo_name = repo.name
+
+            if not repo.repo_filename:
+                repo.repo_filename = f"{repo.name}.repo"
+
+            if not repo.key_filename:
+                repo.key_filename = f"{repo.name}.gpg.key"
+
+            self.extra_files.update(
+                {
+                    f"{repo.name}.gpg.key": repo.key,
+                    f"{repo.name}.repo": REPO_FILE.format(
+                        repo_name=repo.repo_name,
+                        base_url=repo.url,
+                        gpg_key=repo.key_url,
+                    ),
+                }
+            )
+
     def prepare_template(self) -> None:
         """Prepare the custom template used in the build_stage_custom_end."""
         assert self.build_recipe_type == BuildType.DOCKER, (
@@ -236,6 +237,8 @@ class ThirdPartyRepoMixin:
         assert not self.build_stage_custom_end, (
             "Can't use `build_stage_custom_end` for ThirdPartyRepoMixin."
         )
+
+        self.prepare_extra_files()
 
         self.build_stage_custom_end = CUSTOM_END_TEMPLATE.render(
             image=self,

--- a/tests/test_repomdparser.py
+++ b/tests/test_repomdparser.py
@@ -14,30 +14,46 @@ _pkg_template = """<package type="rpm">
   <location href="Packages/{pkg}-{ver}.{arch}.rpm"/>
 </package>"""
 
-_packages = ""
+_sle_packages = ""
+_opensuse_packages = ""
 
 # add out of order to ensure RepoMDParser.parse sorts it properly
 for pkg in [
-    "dummy-pkg-3",
-    "dummy-pkg-1",
-    "dummy-pkg-4",
-    "dummy-pkg-2",
-    "dummy-pkg-6",
-    "dummy-pkg-5",
+    "dummy-sle-pkg-3",
+    "dummy-sle-pkg-1",
+    "dummy-sle-pkg-4",
+    "dummy-sle-pkg-2",
+    "dummy-sle-pkg-6",
+    "dummy-sle-pkg-5",
 ]:
     for arch in ["x86_64", "aarch64"]:
         for ver in ["1.0.0", "1.0.2", "1.0.1"]:
             s = _pkg_template.format(pkg=pkg, arch=arch, ver=ver)
-            _packages += s + "\n"
+            _sle_packages += s + "\n"
 
 SLE_PRIMARY_XML = f"""<?xml version="1.0" encoding="UTF-8"?>
 <metadata xmlns="http://linux.duke.edu/metadata/common" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
-{_packages}
+{_sle_packages}
 </metadata>
 """
 
-OPENSUSE_PRIMARY_XML = """<?xml version="1.0" encoding="UTF-8"?>
+# add out of order to ensure RepoMDParser.parse sorts it properly
+for pkg in [
+    "dummy-opensuse-pkg-3",
+    "dummy-opensuse-pkg-1",
+    "dummy-opensuse-pkg-4",
+    "dummy-opensuse-pkg-2",
+    "dummy-opensuse-pkg-6",
+    "dummy-opensuse-pkg-5",
+]:
+    for arch in ["x86_64", "aarch64"]:
+        for ver in ["1.0.0", "1.0.2", "1.0.1"]:
+            s = _pkg_template.format(pkg=pkg, arch=arch, ver=ver)
+            _opensuse_packages += s + "\n"
+
+OPENSUSE_PRIMARY_XML = f"""<?xml version="1.0" encoding="UTF-8"?>
 <metadata xmlns="http://linux.duke.edu/metadata/common" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+{_opensuse_packages}
 </metadata>
 """
 
@@ -67,28 +83,23 @@ OPENSUSE_REPO_XML = """<?xml version="1.0" encoding="UTF-8"?>
 def fake_repo_get(url, *args, **kwargs):
     resp = Mock()
     resp.raise_for_status.return_value = None
+    resp.status_code = 200
 
-    if url == "https://packages.example.com/sles/15.7/repodata/repomd.xml":
-        resp.content = SLE_REPO_XML
-        resp.status_code = 200
-        return resp
+    match url:
+        case "https://packages.example.com/sles/15.7/repodata/repomd.xml":
+            resp.content = SLE_REPO_XML
+        case "https://packages.example.org/opensuse/15.7/repodata/repomd.xml":
+            resp.content = OPENSUSE_REPO_XML
+        case "https://packages.example.com/sles/15.7/repodata/primary.xml.gz":
+            resp.content = gzip.compress(SLE_PRIMARY_XML.encode("utf-8"))
+        case "https://packages.example.org/opensuse/15.7/repodata/primary.xml.gz":
+            resp.content = gzip.compress(OPENSUSE_PRIMARY_XML.encode("utf-8"))
+        case "https://packages.example.com/keys/repo.asc":
+            resp.text = "GPGKEY"
+        case _:
+            raise ValueError(f"Unexpected URL: {url}")
 
-    if url == "https://packages.example.org/opensuse/15.7/repodata/repomd.xml":
-        resp.content = OPENSUSE_REPO_XML
-        resp.status_code = 200
-        return resp
-
-    if url == "https://packages.example.com/sles/15.7/repodata/primary.xml.gz":
-        resp.content = gzip.compress(SLE_PRIMARY_XML.encode("utf-8"))
-        resp.status_code = 200
-        return resp
-
-    if url == "https://packages.example.org/opensuse/15.7/repodata/primary.xml.gz":
-        resp.content = gzip.compress(OPENSUSE_PRIMARY_XML.encode("utf-8"))
-        resp.status_code = 200
-        return resp
-
-    raise ValueError(f"Unexpected URL: {url}")
+    return resp
 
 
 def test_parse():
@@ -97,27 +108,27 @@ def test_parse():
     with patch("bci_build.repomdparser.requests.get", side_effect=fake_repo_get):
         repo.parse()
 
-    assert repo.pkgs[0].name == "dummy-pkg-1"
+    assert repo.pkgs[0].name == "dummy-sle-pkg-1"
     assert repo.pkgs[0].evr == ("", "1.0.2", "1")
     assert repo.pkgs[0].arch == "aarch64"
 
-    assert repo.pkgs[3].name == "dummy-pkg-1"
+    assert repo.pkgs[3].name == "dummy-sle-pkg-1"
     assert repo.pkgs[3].evr == ("", "1.0.2", "1")
     assert repo.pkgs[3].arch == "x86_64"
 
-    assert repo.pkgs[12].name == "dummy-pkg-3"
+    assert repo.pkgs[12].name == "dummy-sle-pkg-3"
     assert repo.pkgs[12].evr == ("", "1.0.2", "1")
     assert repo.pkgs[12].arch == "aarch64"
 
-    assert repo.pkgs[15].name == "dummy-pkg-3"
+    assert repo.pkgs[15].name == "dummy-sle-pkg-3"
     assert repo.pkgs[15].evr == ("", "1.0.2", "1")
     assert repo.pkgs[15].arch == "x86_64"
 
-    assert repo.pkgs[30].name == "dummy-pkg-6"
+    assert repo.pkgs[30].name == "dummy-sle-pkg-6"
     assert repo.pkgs[30].evr == ("", "1.0.2", "1")
     assert repo.pkgs[30].arch == "aarch64"
 
-    assert repo.pkgs[33].name == "dummy-pkg-6"
+    assert repo.pkgs[33].name == "dummy-sle-pkg-6"
     assert repo.pkgs[33].evr == ("", "1.0.2", "1")
     assert repo.pkgs[33].arch == "x86_64"
 
@@ -128,35 +139,35 @@ def test_query():
     with patch("bci_build.repomdparser.requests.get", side_effect=fake_repo_get):
         repo.parse()
 
-    pkgs = repo.query("dummy-pkg-3")
+    pkgs = repo.query("dummy-sle-pkg-3")
     assert len(pkgs) == 6
-    assert all(pkg.name == "dummy-pkg-3" for pkg in pkgs)
+    assert all(pkg.name == "dummy-sle-pkg-3" for pkg in pkgs)
 
-    pkgs = repo.query("dummy-pkg-2", arch="aarch64")
+    pkgs = repo.query("dummy-sle-pkg-2", arch="aarch64")
     assert len(pkgs) == 3
-    assert all(pkg.name == "dummy-pkg-2" for pkg in pkgs)
+    assert all(pkg.name == "dummy-sle-pkg-2" for pkg in pkgs)
     assert all(pkg.arch == "aarch64" for pkg in pkgs)
 
-    pkgs = repo.query("dummy-pkg-2", arch="x86_64")
+    pkgs = repo.query("dummy-sle-pkg-2", arch="x86_64")
     assert len(pkgs) == 3
-    assert all(pkg.name == "dummy-pkg-2" for pkg in pkgs)
+    assert all(pkg.name == "dummy-sle-pkg-2" for pkg in pkgs)
     assert all(pkg.arch == "x86_64" for pkg in pkgs)
 
-    pkgs = repo.query("dummy-pkg-5", latest=True)
+    pkgs = repo.query("dummy-sle-pkg-5", latest=True)
     assert len(pkgs) == 2
-    assert pkgs[0].name == "dummy-pkg-5"
+    assert pkgs[0].name == "dummy-sle-pkg-5"
     assert pkgs[0].arch == "aarch64"
     assert pkgs[0].evr[1] == "1.0.2"
-    assert pkgs[1].name == "dummy-pkg-5"
+    assert pkgs[1].name == "dummy-sle-pkg-5"
     assert pkgs[1].arch == "x86_64"
     assert pkgs[1].evr[1] == "1.0.2"
 
-    pkgs = repo.query("dummy-pkg-4", arch="aarch64", latest=True)
+    pkgs = repo.query("dummy-sle-pkg-4", arch="aarch64", latest=True)
     assert len(pkgs) == 1
     assert pkgs[0].arch == "aarch64"
     assert pkgs[0].evr[1] == "1.0.2"
 
-    pkgs = repo.query("dummy-pkg-4", arch="x86_64", latest=True)
+    pkgs = repo.query("dummy-sle-pkg-4", arch="x86_64", latest=True)
     assert len(pkgs) == 1
     assert pkgs[0].arch == "x86_64"
     assert pkgs[0].evr[1] == "1.0.2"

--- a/tests/test_thirdparty.py
+++ b/tests/test_thirdparty.py
@@ -14,11 +14,17 @@ class DummyThirdPartyImage(ThirdPartyRepoMixin, DevelopmentContainer):
     pass
 
 
-def fake_key_get(url, *args, **kwargs):
+def fake_repo_and_key_get(url, *args, **kwargs):
     resp = Mock()
     resp.raise_for_status.return_value = None
-    resp.text = "NICE-GPG-KEY"
     resp.status_code = 200
+
+    match url:
+        case "https://packages.example.com/keys/repo.asc":
+            resp.text = "GPGKEY"
+        case _:
+            return fake_repo_get(url, *args, **kwargs)
+
     return resp
 
 
@@ -28,59 +34,59 @@ DOCKERFILE_RENDERED_SINGLE = """# SPDX-License-Identifier: MIT
 
 #!UseOBSRepositories
 #!ExclusiveArch: x86_64 aarch64
-#!BuildTag: bci/dummy-third-party-image:1-%RELEASE%
-#!BuildTag: bci/dummy-third-party-image:1
-#!BuildTag: bci/dummy-third-party-image:latest
-#!BuildName: bci-dummy-third-party-image-1
+#!BuildTag: bci/dummy-sle-repo:1-%RELEASE%
+#!BuildTag: bci/dummy-sle-repo:1
+#!BuildTag: bci/dummy-sle-repo:latest
+#!BuildName: bci-dummy-sle-repo-1
 #!BuildVersion: 15.7.1
 FROM registry.suse.com/bci/bci-base:15.7
 
 RUN \\
     zypper -n install --no-recommends wget
 RUN mkdir -p /tmp/
-#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-pkg-1-1.0.2.aarch64.rpm sha256:value
-COPY dummy-pkg-1-1.0.2.aarch64.rpm /tmp/
-#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-pkg-1-1.0.2.x86_64.rpm sha256:value
-COPY dummy-pkg-1-1.0.2.x86_64.rpm /tmp/
-#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-pkg-3-1.0.2.aarch64.rpm sha256:value
-COPY dummy-pkg-3-1.0.2.aarch64.rpm /tmp/
-#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-pkg-3-1.0.2.x86_64.rpm sha256:value
-COPY dummy-pkg-3-1.0.2.x86_64.rpm /tmp/
-#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-pkg-2-1.0.2.aarch64.rpm sha256:value
-COPY dummy-pkg-2-1.0.2.aarch64.rpm /tmp/
-#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-pkg-2-1.0.2.x86_64.rpm sha256:value
-COPY dummy-pkg-2-1.0.2.x86_64.rpm /tmp/
-#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-pkg-5-1.0.2.aarch64.rpm sha256:value
-COPY dummy-pkg-5-1.0.2.aarch64.rpm /tmp/
-#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-pkg-5-1.0.2.x86_64.rpm sha256:value
-COPY dummy-pkg-5-1.0.2.x86_64.rpm /tmp/
-#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-pkg-4-1.0.2.aarch64.rpm sha256:value
-COPY dummy-pkg-4-1.0.2.aarch64.rpm /tmp/
-#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-pkg-4-1.0.2.x86_64.rpm sha256:value
-COPY dummy-pkg-4-1.0.2.x86_64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-1-1.0.2.aarch64.rpm sha256:value
+COPY dummy-sle-pkg-1-1.0.2.aarch64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-1-1.0.2.x86_64.rpm sha256:value
+COPY dummy-sle-pkg-1-1.0.2.x86_64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-3-1.0.2.aarch64.rpm sha256:value
+COPY dummy-sle-pkg-3-1.0.2.aarch64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-3-1.0.2.x86_64.rpm sha256:value
+COPY dummy-sle-pkg-3-1.0.2.x86_64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-2-1.0.2.aarch64.rpm sha256:value
+COPY dummy-sle-pkg-2-1.0.2.aarch64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-2-1.0.2.x86_64.rpm sha256:value
+COPY dummy-sle-pkg-2-1.0.2.x86_64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-5-1.0.2.aarch64.rpm sha256:value
+COPY dummy-sle-pkg-5-1.0.2.aarch64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-5-1.0.2.x86_64.rpm sha256:value
+COPY dummy-sle-pkg-5-1.0.2.x86_64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-4-1.0.2.aarch64.rpm sha256:value
+COPY dummy-sle-pkg-4-1.0.2.aarch64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-4-1.0.2.x86_64.rpm sha256:value
+COPY dummy-sle-pkg-4-1.0.2.x86_64.rpm /tmp/
 
-COPY third-party.gpg.key /tmp/dummy-third-party-image.gpg.key
-RUN rpm --import /tmp/dummy-third-party-image.gpg.key
+COPY sle.gpg.key /tmp/dummy-sle-repo.gpg.key
+RUN rpm --import /tmp/dummy-sle-repo.gpg.key
 
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then \\
         zypper -n install \\
-            /tmp/dummy-pkg-1-1.0.2.x86_64.rpm \\
-            /tmp/dummy-pkg-3-1.0.2.x86_64.rpm \\
-            /tmp/dummy-pkg-2-1.0.2.x86_64.rpm \\
-            /tmp/dummy-pkg-5-1.0.2.x86_64.rpm \\
-            /tmp/dummy-pkg-4-1.0.2.x86_64.rpm; \\
+            /tmp/dummy-sle-pkg-1-1.0.2.x86_64.rpm \\
+            /tmp/dummy-sle-pkg-3-1.0.2.x86_64.rpm \\
+            /tmp/dummy-sle-pkg-2-1.0.2.x86_64.rpm \\
+            /tmp/dummy-sle-pkg-5-1.0.2.x86_64.rpm \\
+            /tmp/dummy-sle-pkg-4-1.0.2.x86_64.rpm; \\
     fi
 RUN if [ "$(uname -m)" = "aarch64" ]; then \\
         zypper -n install \\
-            /tmp/dummy-pkg-1-1.0.2.aarch64.rpm \\
-            /tmp/dummy-pkg-3-1.0.2.aarch64.rpm \\
-            /tmp/dummy-pkg-2-1.0.2.aarch64.rpm \\
-            /tmp/dummy-pkg-5-1.0.2.aarch64.rpm \\
-            /tmp/dummy-pkg-4-1.0.2.aarch64.rpm; \\
+            /tmp/dummy-sle-pkg-1-1.0.2.aarch64.rpm \\
+            /tmp/dummy-sle-pkg-3-1.0.2.aarch64.rpm \\
+            /tmp/dummy-sle-pkg-2-1.0.2.aarch64.rpm \\
+            /tmp/dummy-sle-pkg-5-1.0.2.aarch64.rpm \\
+            /tmp/dummy-sle-pkg-4-1.0.2.aarch64.rpm; \\
     fi
 
-COPY third-party.repo /etc/zypp/repos.d/dummy-third-party-image.repo
+COPY sle.repo /etc/zypp/repos.d/dummy-sle-repo.repo
 
 RUN rm -rf /tmp/*
 
@@ -91,7 +97,7 @@ RUN zypper -n clean -a; \\
 RUN sed -i 's/^\\([^:]*:[^:]*:\\)[^:]*\\(:.*\\)$/\\1\\2/' /etc/shadow
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
-# labelprefix=com.suse.bci.dummy-third-party-image
+# labelprefix=com.suse.bci.dummy-sle-repo
 LABEL org.opencontainers.image.authors="https://github.com/SUSE/bci/discussions"
 LABEL org.opencontainers.image.title="Dummy Third Party Image for SUSE Linux Enterprise Server 15 SP7"
 LABEL org.opencontainers.image.description="Dummy Third Party Image container based on the SUSE Linux Enterprise Base Container Image."
@@ -101,7 +107,7 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 LABEL org.opencontainers.image.vendor="SUSE LLC"
 LABEL org.opencontainers.image.source="%SOURCEURL%"
 LABEL org.opencontainers.image.ref.name="1-%RELEASE%"
-LABEL org.opensuse.reference="registry.suse.com/bci/dummy-third-party-image:1-%RELEASE%"
+LABEL org.opensuse.reference="registry.suse.com/bci/dummy-sle-repo:1-%RELEASE%"
 LABEL org.openbuildservice.disturl="%DISTURL%"
 LABEL com.suse.supportlevel="techpreview"
 LABEL com.suse.eula="sle-bci"
@@ -119,62 +125,62 @@ DOCKERFILE_RENDERED_MULTI = """# SPDX-License-Identifier: MIT
 
 #!UseOBSRepositories
 #!ExclusiveArch: x86_64 aarch64
-#!BuildTag: bci/dummy-third-party-image:1-%RELEASE%
-#!BuildTag: bci/dummy-third-party-image:1
-#!BuildTag: bci/dummy-third-party-image:latest
-#!BuildName: bci-dummy-third-party-image-1
+#!BuildTag: bci/dummy-sle-repo:1-%RELEASE%
+#!BuildTag: bci/dummy-sle-repo:1
+#!BuildTag: bci/dummy-sle-repo:latest
+#!BuildName: bci-dummy-sle-repo-1
 #!BuildVersion: 15.7.1
 FROM registry.suse.com/bci/bci-base:15.7
 
 RUN \\
     zypper -n install --no-recommends wget
 RUN mkdir -p /tmp/
-#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-pkg-1-1.0.2.aarch64.rpm sha256:value
-COPY dummy-pkg-1-1.0.2.aarch64.rpm /tmp/
-#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-pkg-1-1.0.2.x86_64.rpm sha256:value
-COPY dummy-pkg-1-1.0.2.x86_64.rpm /tmp/
-#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-pkg-3-1.0.2.aarch64.rpm sha256:value
-COPY dummy-pkg-3-1.0.2.aarch64.rpm /tmp/
-#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-pkg-3-1.0.2.x86_64.rpm sha256:value
-COPY dummy-pkg-3-1.0.2.x86_64.rpm /tmp/
-#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-pkg-2-1.0.2.aarch64.rpm sha256:value
-COPY dummy-pkg-2-1.0.2.aarch64.rpm /tmp/
-#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-pkg-2-1.0.2.x86_64.rpm sha256:value
-COPY dummy-pkg-2-1.0.2.x86_64.rpm /tmp/
-#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-pkg-5-1.0.2.aarch64.rpm sha256:value
-COPY dummy-pkg-5-1.0.2.aarch64.rpm /tmp/
-#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-pkg-5-1.0.2.x86_64.rpm sha256:value
-COPY dummy-pkg-5-1.0.2.x86_64.rpm /tmp/
-#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-pkg-4-1.0.2.aarch64.rpm sha256:value
-COPY dummy-pkg-4-1.0.2.aarch64.rpm /tmp/
-#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-pkg-4-1.0.2.x86_64.rpm sha256:value
-COPY dummy-pkg-4-1.0.2.x86_64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-1-1.0.2.aarch64.rpm sha256:value
+COPY dummy-sle-pkg-1-1.0.2.aarch64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-1-1.0.2.x86_64.rpm sha256:value
+COPY dummy-sle-pkg-1-1.0.2.x86_64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.org/opensuse/15.7/Packages/dummy-opensuse-pkg-3-1.0.2.aarch64.rpm sha256:value
+COPY dummy-opensuse-pkg-3-1.0.2.aarch64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.org/opensuse/15.7/Packages/dummy-opensuse-pkg-3-1.0.2.x86_64.rpm sha256:value
+COPY dummy-opensuse-pkg-3-1.0.2.x86_64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-2-1.0.2.aarch64.rpm sha256:value
+COPY dummy-sle-pkg-2-1.0.2.aarch64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-2-1.0.2.x86_64.rpm sha256:value
+COPY dummy-sle-pkg-2-1.0.2.x86_64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.org/opensuse/15.7/Packages/dummy-opensuse-pkg-5-1.0.2.aarch64.rpm sha256:value
+COPY dummy-opensuse-pkg-5-1.0.2.aarch64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.org/opensuse/15.7/Packages/dummy-opensuse-pkg-5-1.0.2.x86_64.rpm sha256:value
+COPY dummy-opensuse-pkg-5-1.0.2.x86_64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-4-1.0.2.aarch64.rpm sha256:value
+COPY dummy-sle-pkg-4-1.0.2.aarch64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-4-1.0.2.x86_64.rpm sha256:value
+COPY dummy-sle-pkg-4-1.0.2.x86_64.rpm /tmp/
 
-COPY third-party.gpg.key /tmp/dummy-third-party-image.gpg.key
-RUN rpm --import /tmp/dummy-third-party-image.gpg.key
-COPY third-party-2.gpg.key /tmp/dummy-third-party-image-2.gpg.key
-RUN rpm --import /tmp/dummy-third-party-image-2.gpg.key
+COPY sle.gpg.key /tmp/dummy-sle-repo.gpg.key
+RUN rpm --import /tmp/dummy-sle-repo.gpg.key
+COPY opensuse.gpg.key /tmp/dummy-opensuse-repo.gpg.key
+RUN rpm --import /tmp/dummy-opensuse-repo.gpg.key
 
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then \\
         zypper -n install \\
-            /tmp/dummy-pkg-1-1.0.2.x86_64.rpm \\
-            /tmp/dummy-pkg-3-1.0.2.x86_64.rpm \\
-            /tmp/dummy-pkg-2-1.0.2.x86_64.rpm \\
-            /tmp/dummy-pkg-5-1.0.2.x86_64.rpm \\
-            /tmp/dummy-pkg-4-1.0.2.x86_64.rpm; \\
+            /tmp/dummy-sle-pkg-1-1.0.2.x86_64.rpm \\
+            /tmp/dummy-opensuse-pkg-3-1.0.2.x86_64.rpm \\
+            /tmp/dummy-sle-pkg-2-1.0.2.x86_64.rpm \\
+            /tmp/dummy-opensuse-pkg-5-1.0.2.x86_64.rpm \\
+            /tmp/dummy-sle-pkg-4-1.0.2.x86_64.rpm; \\
     fi
 RUN if [ "$(uname -m)" = "aarch64" ]; then \\
         zypper -n install \\
-            /tmp/dummy-pkg-1-1.0.2.aarch64.rpm \\
-            /tmp/dummy-pkg-3-1.0.2.aarch64.rpm \\
-            /tmp/dummy-pkg-2-1.0.2.aarch64.rpm \\
-            /tmp/dummy-pkg-5-1.0.2.aarch64.rpm \\
-            /tmp/dummy-pkg-4-1.0.2.aarch64.rpm; \\
+            /tmp/dummy-sle-pkg-1-1.0.2.aarch64.rpm \\
+            /tmp/dummy-opensuse-pkg-3-1.0.2.aarch64.rpm \\
+            /tmp/dummy-sle-pkg-2-1.0.2.aarch64.rpm \\
+            /tmp/dummy-opensuse-pkg-5-1.0.2.aarch64.rpm \\
+            /tmp/dummy-sle-pkg-4-1.0.2.aarch64.rpm; \\
     fi
 
-COPY third-party.repo /etc/zypp/repos.d/dummy-third-party-image.repo
-COPY third-party-2.repo /etc/zypp/repos.d/dummy-third-party-image-2.repo
+COPY sle.repo /etc/zypp/repos.d/dummy-sle-repo.repo
+COPY opensuse.repo /etc/zypp/repos.d/dummy-opensuse-repo.repo
 
 RUN rm -rf /tmp/*
 
@@ -185,7 +191,7 @@ RUN zypper -n clean -a; \\
 RUN sed -i 's/^\\([^:]*:[^:]*:\\)[^:]*\\(:.*\\)$/\\1\\2/' /etc/shadow
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
-# labelprefix=com.suse.bci.dummy-third-party-image
+# labelprefix=com.suse.bci.dummy-sle-repo
 LABEL org.opencontainers.image.authors="https://github.com/SUSE/bci/discussions"
 LABEL org.opencontainers.image.title="Dummy Third Party Image for SUSE Linux Enterprise Server 15 SP7"
 LABEL org.opencontainers.image.description="Dummy Third Party Image container based on the SUSE Linux Enterprise Base Container Image."
@@ -195,7 +201,7 @@ LABEL org.opencontainers.image.created="%BUILDTIME%"
 LABEL org.opencontainers.image.vendor="SUSE LLC"
 LABEL org.opencontainers.image.source="%SOURCEURL%"
 LABEL org.opencontainers.image.ref.name="1-%RELEASE%"
-LABEL org.opensuse.reference="registry.suse.com/bci/dummy-third-party-image:1-%RELEASE%"
+LABEL org.opensuse.reference="registry.suse.com/bci/dummy-sle-repo:1-%RELEASE%"
 LABEL org.openbuildservice.disturl="%DISTURL%"
 LABEL com.suse.supportlevel="techpreview"
 LABEL com.suse.eula="sle-bci"
@@ -207,55 +213,157 @@ LABEL org.opencontainers.image.base.digest="%BASE_DIGEST%"
 LABEL io.artifacthub.package.readme-url="%SOURCEURL_WITH(README.md)%"
 """
 
-SLE_REPO_RENDERED = """[dummy-third-party-image]
-name=dummy-third-party-image
+DOCKERFILE_RENDERED_KEY_FETCH = """# SPDX-License-Identifier: MIT
+
+# Copyright
+
+#!UseOBSRepositories
+#!ExclusiveArch: x86_64 aarch64
+#!BuildTag: bci/dummy-sle-repo:1-%RELEASE%
+#!BuildTag: bci/dummy-sle-repo:1
+#!BuildTag: bci/dummy-sle-repo:latest
+#!BuildName: bci-dummy-sle-repo-1
+#!BuildVersion: 15.7.1
+FROM registry.suse.com/bci/bci-base:15.7
+
+RUN \\
+    zypper -n install --no-recommends wget
+RUN mkdir -p /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-1-1.0.2.aarch64.rpm sha256:value
+COPY dummy-sle-pkg-1-1.0.2.aarch64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-1-1.0.2.x86_64.rpm sha256:value
+COPY dummy-sle-pkg-1-1.0.2.x86_64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-3-1.0.2.aarch64.rpm sha256:value
+COPY dummy-sle-pkg-3-1.0.2.aarch64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-3-1.0.2.x86_64.rpm sha256:value
+COPY dummy-sle-pkg-3-1.0.2.x86_64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-2-1.0.2.aarch64.rpm sha256:value
+COPY dummy-sle-pkg-2-1.0.2.aarch64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-2-1.0.2.x86_64.rpm sha256:value
+COPY dummy-sle-pkg-2-1.0.2.x86_64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-5-1.0.2.aarch64.rpm sha256:value
+COPY dummy-sle-pkg-5-1.0.2.aarch64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-5-1.0.2.x86_64.rpm sha256:value
+COPY dummy-sle-pkg-5-1.0.2.x86_64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-4-1.0.2.aarch64.rpm sha256:value
+COPY dummy-sle-pkg-4-1.0.2.aarch64.rpm /tmp/
+#!RemoteAssetUrl: https://packages.example.com/sles/15.7/Packages/dummy-sle-pkg-4-1.0.2.x86_64.rpm sha256:value
+COPY dummy-sle-pkg-4-1.0.2.x86_64.rpm /tmp/
+
+COPY sle.gpg.key /tmp/sle.gpg.key
+RUN rpm --import /tmp/sle.gpg.key
+
+
+RUN if [ "$(uname -m)" = "x86_64" ]; then \\
+        zypper -n install \\
+            /tmp/dummy-sle-pkg-1-1.0.2.x86_64.rpm \\
+            /tmp/dummy-sle-pkg-3-1.0.2.x86_64.rpm \\
+            /tmp/dummy-sle-pkg-2-1.0.2.x86_64.rpm \\
+            /tmp/dummy-sle-pkg-5-1.0.2.x86_64.rpm \\
+            /tmp/dummy-sle-pkg-4-1.0.2.x86_64.rpm; \\
+    fi
+RUN if [ "$(uname -m)" = "aarch64" ]; then \\
+        zypper -n install \\
+            /tmp/dummy-sle-pkg-1-1.0.2.aarch64.rpm \\
+            /tmp/dummy-sle-pkg-3-1.0.2.aarch64.rpm \\
+            /tmp/dummy-sle-pkg-2-1.0.2.aarch64.rpm \\
+            /tmp/dummy-sle-pkg-5-1.0.2.aarch64.rpm \\
+            /tmp/dummy-sle-pkg-4-1.0.2.aarch64.rpm; \\
+    fi
+
+COPY sle.repo /etc/zypp/repos.d/sle.repo
+
+RUN rm -rf /tmp/*
+
+# cleanup logs and temporary files
+RUN zypper -n clean -a; \\
+    # LOGCLEAN #
+# set the day of last password change to empty
+RUN sed -i 's/^\\([^:]*:[^:]*:\\)[^:]*\\(:.*\\)$/\\1\\2/' /etc/shadow
+
+# Define labels according to https://en.opensuse.org/Building_derived_containers
+# labelprefix=com.suse.bci.dummy-sle-repo
+LABEL org.opencontainers.image.authors="https://github.com/SUSE/bci/discussions"
+LABEL org.opencontainers.image.title="Dummy Third Party Image for SUSE Linux Enterprise Server 15 SP7"
+LABEL org.opencontainers.image.description="Dummy Third Party Image container based on the SUSE Linux Enterprise Base Container Image."
+LABEL org.opencontainers.image.version="1"
+LABEL org.opencontainers.image.url="https://www.suse.com/products/base-container-images/"
+LABEL org.opencontainers.image.created="%BUILDTIME%"
+LABEL org.opencontainers.image.vendor="SUSE LLC"
+LABEL org.opencontainers.image.source="%SOURCEURL%"
+LABEL org.opencontainers.image.ref.name="1-%RELEASE%"
+LABEL org.opensuse.reference="registry.suse.com/bci/dummy-sle-repo:1-%RELEASE%"
+LABEL org.openbuildservice.disturl="%DISTURL%"
+LABEL com.suse.supportlevel="techpreview"
+LABEL com.suse.eula="sle-bci"
+LABEL com.suse.lifecycle-url="https://www.suse.com/lifecycle#suse-linux-enterprise-server-15"
+LABEL com.suse.release-stage="released"
+# endlabelprefix
+LABEL org.opencontainers.image.base.name="%BASE_REFNAME%"
+LABEL org.opencontainers.image.base.digest="%BASE_DIGEST%"
+LABEL io.artifacthub.package.readme-url="%SOURCEURL_WITH(README.md)%"
+"""
+
+SLE_REPO_RENDERED = """[dummy-sle-repo]
+name=dummy-sle-repo
 baseurl=https://packages.example.com/sles/15.7/
 enabled=1
 gpgcheck=1
 gpgkey=https://packages.example.com/keys/repo.asc
 """
 
-OPENSUSE_REPO_RENDERED = """[dummy-third-party-image-2]
-name=dummy-third-party-image-2
+OPENSUSE_REPO_RENDERED = """[dummy-opensuse-repo]
+name=dummy-opensuse-repo
 baseurl=https://packages.example.org/opensuse/15.7/
 enabled=1
 gpgcheck=1
 gpgkey=https://packages.example.org/keys/repo.asc
 """
 
+KEY_FETCH_REPO_RENDERED = """[sle]
+name=sle
+baseurl=https://packages.example.com/sles/15.7/
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.example.com/keys/repo.asc
+"""
+
 
 def test_single_third_party_repo_template():
+    """Test a single third party repositories."""
     image = DummyThirdPartyImage(
         tag_version="1",
         version="1",
         os_version=OsVersion.SP7,
-        name="dummy-third-party-image",
+        name="dummy-sle-repo",
         pretty_name="Dummy Third Party Image",
         is_latest=True,
-        package_name="dummy-third-party-image",
+        package_name="dummy-sle-repo",
         exclusive_arch=[Arch.X86_64, Arch.AARCH64],
         package_list=["wget"],
         third_party_repos=[
             ThirdPartyRepo(
-                name="third-party",
+                name="sle",
                 url="https://packages.example.com/sles/15.7/",
                 key="GPGKEY",
                 key_url="https://packages.example.com/keys/repo.asc",
-                repo_name="dummy-third-party-image",
-                repo_filename="dummy-third-party-image.repo",
-                key_filename="dummy-third-party-image.gpg.key",
+                repo_name="dummy-sle-repo",
+                repo_filename="dummy-sle-repo.repo",
+                key_filename="dummy-sle-repo.gpg.key",
             ),
         ],
         third_party_package_list=[
-            "dummy-pkg-1",
-            "dummy-pkg-3",
-            "dummy-pkg-2",
-            "dummy-pkg-5",
-            "dummy-pkg-4",
+            "dummy-sle-pkg-1",
+            "dummy-sle-pkg-3",
+            "dummy-sle-pkg-2",
+            "dummy-sle-pkg-5",
+            "dummy-sle-pkg-4",
         ],
     )
 
-    with patch("bci_build.repomdparser.requests.get", side_effect=fake_repo_get):
+    with patch(
+        "bci_build.repomdparser.requests.get", side_effect=fake_repo_and_key_get
+    ):
         image.prepare_template()
 
     rendered = DOCKERFILE_TEMPLATE.render(
@@ -264,150 +372,159 @@ def test_single_third_party_repo_template():
         DOCKERFILE_RUN="RUN",
         LOG_CLEAN="# LOGCLEAN #",
         BUILD_FLAVOR=image.build_flavor,
-    )
-
-    assert rendered == DOCKERFILE_RENDERED_SINGLE
-
-    assert image.extra_files.get("third-party.gpg.key") == "GPGKEY"
-    assert image.extra_files.get("third-party.repo") == SLE_REPO_RENDERED
-
-
-def test_multiple_third_party_repo_template():
-    image = DummyThirdPartyImage(
-        tag_version="1",
-        version="1",
-        os_version=OsVersion.SP7,
-        name="dummy-third-party-image",
-        pretty_name="Dummy Third Party Image",
-        is_latest=True,
-        package_name="dummy-third-party-image",
-        exclusive_arch=[Arch.X86_64, Arch.AARCH64],
-        package_list=["wget"],
-        third_party_repos=[
-            ThirdPartyRepo(
-                name="third-party",
-                url="https://packages.example.com/sles/15.7/",
-                key="GPGKEY",
-                key_url="https://packages.example.com/keys/repo.asc",
-                repo_name="dummy-third-party-image",
-                repo_filename="dummy-third-party-image.repo",
-                key_filename="dummy-third-party-image.gpg.key",
-            ),
-            ThirdPartyRepo(
-                name="third-party-2",
-                url="https://packages.example.org/opensuse/15.7/",
-                key="GPGKEY",
-                key_url="https://packages.example.org/keys/repo.asc",
-                repo_name="dummy-third-party-image-2",
-                repo_filename="dummy-third-party-image-2.repo",
-                key_filename="dummy-third-party-image-2.gpg.key",
-            ),
-        ],
-        third_party_package_list=[
-            "dummy-pkg-1",
-            "dummy-pkg-3",
-            "dummy-pkg-2",
-            "dummy-pkg-5",
-            "dummy-pkg-4",
-        ],
-    )
-
-    with patch("bci_build.repomdparser.requests.get", side_effect=fake_repo_get):
-        image.prepare_template()
-
-    rendered = DOCKERFILE_TEMPLATE.render(
-        image=image,
-        INFOHEADER="# Copyright",
-        DOCKERFILE_RUN="RUN",
-        LOG_CLEAN="# LOGCLEAN #",
-        BUILD_FLAVOR=image.build_flavor,
-    )
-
-    assert rendered == DOCKERFILE_RENDERED_MULTI
-
-    assert image.extra_files.get("third-party.gpg.key") == "GPGKEY"
-    assert image.extra_files.get("third-party.repo") == SLE_REPO_RENDERED
-
-    assert image.extra_files.get("third-party-2.gpg.key") == "GPGKEY"
-    assert image.extra_files.get("third-party-2.repo") == OPENSUSE_REPO_RENDERED
-
-
-def test_third_party_repo():
-    image = DummyThirdPartyImage(
-        tag_version="1",
-        version="1",
-        os_version=OsVersion.SP7,
-        name="dummy-third-party-image",
-        pretty_name="Dummy Third Party Image",
-        is_latest=True,
-        package_name="dummy-third-party-image",
-        exclusive_arch=[Arch.X86_64, Arch.AARCH64],
-        package_list=["wget"],
-        third_party_repos=[
-            ThirdPartyRepo(
-                name="third-party",
-                url="https://packages.example.com/sles/15.7/",
-                key="GPGKEY",
-                key_url="https://packages.example.com/keys/repo.asc",
-                repo_name="dummy-third-party-image",
-                repo_filename="dummy-third-party-image.repo",
-                key_filename="dummy-third-party-image.gpg.key",
-            ),
-        ],
-        third_party_package_list=[
-            "dummy-pkg-1",
-            "dummy-pkg-3",
-            "dummy-pkg-2",
-            "dummy-pkg-5",
-            "dummy-pkg-4",
-        ],
     )
 
     repo = image.third_party_repos[0]
-
-    assert repo.name == "third-party"
+    assert repo.name == "sle"
     assert repo.url == "https://packages.example.com/sles/15.7/"
     assert repo.key == "GPGKEY"
     assert repo.key_url == "https://packages.example.com/keys/repo.asc"
     assert repo.arch is None
-    assert repo.repo_name == "dummy-third-party-image"
-    assert repo.repo_filename == "dummy-third-party-image.repo"
-    assert repo.key_filename == "dummy-third-party-image.gpg.key"
+    assert repo.repo_name == "dummy-sle-repo"
+    assert repo.repo_filename == "dummy-sle-repo.repo"
+    assert repo.key_filename == "dummy-sle-repo.gpg.key"
 
-    with patch("bci_build.package.thirdparty.requests.get", side_effect=fake_key_get):
-        image = DummyThirdPartyImage(
-            tag_version="1",
-            version="1",
-            os_version=OsVersion.SP7,
-            name="dummy-third-party-image",
-            pretty_name="Dummy Third Party Image",
-            is_latest=True,
-            package_name="dummy-third-party-image",
-            exclusive_arch=[Arch.X86_64, Arch.AARCH64],
-            package_list=["wget"],
-            third_party_repos=[
-                ThirdPartyRepo(
-                    name="third-party",
-                    url="https://packages.example.com/sles/15.7/",
-                    key_url="https://packages.example.com/keys/repo.asc",
-                ),
-            ],
-            third_party_package_list=[
-                "dummy-pkg-1",
-                "dummy-pkg-3",
-                "dummy-pkg-2",
-                "dummy-pkg-5",
-                "dummy-pkg-4",
-            ],
-        )
+    assert rendered == DOCKERFILE_RENDERED_SINGLE
 
-        repo = image.third_party_repos[0]
+    assert image.extra_files.get("sle.gpg.key") == "GPGKEY"
+    assert image.extra_files.get("sle.repo") == SLE_REPO_RENDERED
 
-        assert repo.name == "third-party"
-        assert repo.url == "https://packages.example.com/sles/15.7/"
-        assert repo.key == "NICE-GPG-KEY"
-        assert repo.key_url == "https://packages.example.com/keys/repo.asc"
-        assert repo.arch is None
-        assert repo.repo_name == "third-party"
-        assert repo.repo_filename == "third-party.repo"
-        assert repo.key_filename == "third-party.gpg.key"
+
+def test_multiple_third_party_repo_template():
+    """Test multiple third party repositories."""
+    image = DummyThirdPartyImage(
+        tag_version="1",
+        version="1",
+        os_version=OsVersion.SP7,
+        name="dummy-sle-repo",
+        pretty_name="Dummy Third Party Image",
+        is_latest=True,
+        package_name="dummy-sle-repo",
+        exclusive_arch=[Arch.X86_64, Arch.AARCH64],
+        package_list=["wget"],
+        third_party_repos=[
+            ThirdPartyRepo(
+                name="sle",
+                url="https://packages.example.com/sles/15.7/",
+                key="SLE-GPGKEY",
+                key_url="https://packages.example.com/keys/repo.asc",
+                repo_name="dummy-sle-repo",
+                repo_filename="dummy-sle-repo.repo",
+                key_filename="dummy-sle-repo.gpg.key",
+            ),
+            ThirdPartyRepo(
+                name="opensuse",
+                url="https://packages.example.org/opensuse/15.7/",
+                key="OPENSUSE-GPGKEY",
+                key_url="https://packages.example.org/keys/repo.asc",
+                repo_name="dummy-opensuse-repo",
+                repo_filename="dummy-opensuse-repo.repo",
+                key_filename="dummy-opensuse-repo.gpg.key",
+            ),
+        ],
+        third_party_package_list=[
+            "dummy-sle-pkg-1",
+            "dummy-opensuse-pkg-3",
+            "dummy-sle-pkg-2",
+            "dummy-opensuse-pkg-5",
+            "dummy-sle-pkg-4",
+        ],
+    )
+
+    with patch(
+        "bci_build.repomdparser.requests.get", side_effect=fake_repo_and_key_get
+    ):
+        image.prepare_template()
+
+    rendered = DOCKERFILE_TEMPLATE.render(
+        image=image,
+        INFOHEADER="# Copyright",
+        DOCKERFILE_RUN="RUN",
+        LOG_CLEAN="# LOGCLEAN #",
+        BUILD_FLAVOR=image.build_flavor,
+    )
+
+    repo = image.third_party_repos[0]
+    assert repo.name == "sle"
+    assert repo.url == "https://packages.example.com/sles/15.7/"
+    assert repo.key == "SLE-GPGKEY"
+    assert repo.key_url == "https://packages.example.com/keys/repo.asc"
+    assert repo.arch is None
+    assert repo.repo_name == "dummy-sle-repo"
+    assert repo.repo_filename == "dummy-sle-repo.repo"
+    assert repo.key_filename == "dummy-sle-repo.gpg.key"
+
+    repo = image.third_party_repos[1]
+    assert repo.name == "opensuse"
+    assert repo.url == "https://packages.example.org/opensuse/15.7/"
+    assert repo.key == "OPENSUSE-GPGKEY"
+    assert repo.key_url == "https://packages.example.org/keys/repo.asc"
+    assert repo.arch is None
+    assert repo.repo_name == "dummy-opensuse-repo"
+    assert repo.repo_filename == "dummy-opensuse-repo.repo"
+    assert repo.key_filename == "dummy-opensuse-repo.gpg.key"
+
+    assert rendered == DOCKERFILE_RENDERED_MULTI
+
+    assert image.extra_files.get("sle.gpg.key") == "SLE-GPGKEY"
+    assert image.extra_files.get("sle.repo") == SLE_REPO_RENDERED
+
+    assert image.extra_files.get("opensuse.gpg.key") == "OPENSUSE-GPGKEY"
+    assert image.extra_files.get("opensuse.repo") == OPENSUSE_REPO_RENDERED
+
+
+def test_third_party_key_fetch():
+    """Test that the GPG key is fetched from the configured url."""
+    image = DummyThirdPartyImage(
+        tag_version="1",
+        version="1",
+        os_version=OsVersion.SP7,
+        name="dummy-sle-repo",
+        pretty_name="Dummy Third Party Image",
+        is_latest=True,
+        package_name="dummy-sle-repo",
+        exclusive_arch=[Arch.X86_64, Arch.AARCH64],
+        package_list=["wget"],
+        third_party_repos=[
+            ThirdPartyRepo(
+                name="sle",
+                url="https://packages.example.com/sles/15.7/",
+                key_url="https://packages.example.com/keys/repo.asc",
+            ),
+        ],
+        third_party_package_list=[
+            "dummy-sle-pkg-1",
+            "dummy-sle-pkg-3",
+            "dummy-sle-pkg-2",
+            "dummy-sle-pkg-5",
+            "dummy-sle-pkg-4",
+        ],
+    )
+
+    with patch(
+        "bci_build.package.thirdparty.requests.get", side_effect=fake_repo_and_key_get
+    ):
+        image.prepare_template()
+
+    repo = image.third_party_repos[0]
+    assert repo.name == "sle"
+    assert repo.url == "https://packages.example.com/sles/15.7/"
+    assert repo.key == "GPGKEY"
+    assert repo.key_url == "https://packages.example.com/keys/repo.asc"
+    assert repo.arch is None
+    assert repo.repo_name == "sle"
+    assert repo.repo_filename == "sle.repo"
+    assert repo.key_filename == "sle.gpg.key"
+
+    rendered = DOCKERFILE_TEMPLATE.render(
+        image=image,
+        INFOHEADER="# Copyright",
+        DOCKERFILE_RUN="RUN",
+        LOG_CLEAN="# LOGCLEAN #",
+        BUILD_FLAVOR=image.build_flavor,
+    )
+
+    assert rendered == DOCKERFILE_RENDERED_KEY_FETCH
+
+    assert image.extra_files.get("sle.gpg.key") == "GPGKEY"
+    assert image.extra_files.get("sle.repo") == KEY_FETCH_REPO_RENDERED


### PR DESCRIPTION
Requests outside prepare_template slow down startup. This moves the GPG key request to a new helper function used in prepare_template.

Because NVIDIA has its own custom template, it requires invoking prepare_extra_files as well.