### PR TITLE
Explicitly install coreutils-single in the derived applications

### DIFF
--- a/src/bci_build/package/mariadb.py
+++ b/src/bci_build/package/mariadb.py
@@ -98,18 +98,20 @@ for os_version in (
                     package_name="mariadb",
                 ),
             ],
-            package_list=[
-                "coreutils",
-                "findutils",
-                "gawk",
-                "mariadb",
-                "mariadb-tools",
-                "openssl",
-                "sed",
-                "timezone",
-                "util-linux",
-                "zstd",
-            ],
+            package_list=sorted(
+                [
+                    "findutils",
+                    "gawk",
+                    "mariadb",
+                    "mariadb-tools",
+                    "openssl",
+                    "sed",
+                    "timezone",
+                    "util-linux",
+                    "zstd",
+                ]
+                + (["coreutils-single"] if not os_version.is_sle15 else ["coreutils"])
+            ),
             entrypoint=[_ENTRYPOINT_FNAME],
             license="GPL-2.0-only",
             extra_files={

--- a/src/bci_build/package/postgres.py
+++ b/src/bci_build/package/postgres.py
@@ -51,7 +51,6 @@ POSTGRES_CONTAINERS = [
                 "libpq5",
                 f"postgresql{ver}-server",
                 "findutils",
-                "coreutils",
                 "grep",
                 "sed",
                 "tar",
@@ -59,6 +58,7 @@ POSTGRES_CONTAINERS = [
                 "zstd",
                 "util-linux",  # for setpriv :-(
             ]
+            + (["coreutils-single"] if not os_version.is_sle15 else ["coreutils"])
             + (
                 [
                     f"postgresql{ver}-pgvector",


### PR DESCRIPTION
This is needed to avoid busybox-links being picked.