### PR TITLE
Do not install coreutils explicitly

### DIFF
--- a/src/bci_build/package/nvidia.py
+++ b/src/bci_build/package/nvidia.py
@@ -595,7 +595,6 @@ def _get_packages(os_version: OsVersion):
         Package("xz", PackageType.BOOTSTRAP),
         # needed by nvidia-driver script
         Package("awk", PackageType.IMAGE),
-        Package("coreutils", PackageType.IMAGE),
         Package("findutils", PackageType.IMAGE),
         Package("grep", PackageType.IMAGE),
         Package("jq", PackageType.IMAGE),


### PR DESCRIPTION
coreutils "compatibility" is part of bci-micro (either provided via coreutils or coreutils-single)