### PR TITLE
Update event loop for 3.14

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -1637,7 +1637,9 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
     loop.run_until_complete(
         ALL_CONTAINER_IMAGE_NAMES[args.image[0]].write_files_to_folder(
             args.destination[0]

--- a/src/staging/bot.py
+++ b/src/staging/bot.py
@@ -1696,7 +1696,9 @@ comma-separated list. The package list is taken from the environment variable
         help="Get the full urls to the containers built in the staging project",
     )
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
     args = parser.parse_args()
 
     if args.load and args.from_stdin:


### PR DESCRIPTION
In 3.14 get_event_loop raises a RuntimeError if there is no current event loop.