### PR TITLE
Fix package name for cdi + reduce to minor version

### DIFF
--- a/src/bci_build/package/kubevirt_cdi.py
+++ b/src/bci_build/package/kubevirt_cdi.py
@@ -58,7 +58,7 @@ def _get_cdi_kwargs(
         "name": f"cdi-{service}",
         "pretty_name": f"KubeVirt cdi-{service}",
         "package_name": (
-            "cdi-1.8-image" if os_version == OsVersion.TUMBLEWEED else "cdi-image"
+            "cdi-1.65-image" if os_version == OsVersion.TUMBLEWEED else "cdi-image"
         ),
         "license": "Apache-2.0",
         "os_version": os_version,
@@ -90,8 +90,8 @@ def _get_cdi_kwargs(
         + (
             generate_package_version_check(
                 service_pkg_name,
-                cdi_version,
-                ParseVersion.PATCH,
+                tag_version,
+                ParseVersion.MINOR,
                 use_target=True,
             )
             + (

--- a/src/bci_build/package/package_versions.json
+++ b/src/bci_build/package/package_versions.json
@@ -16,9 +16,9 @@
     },
     "containerized-data-importer1.65": {
         "latest": {
-            "Tumbleweed": "1.65.0"
+            "Tumbleweed": "1.65"
         },
-        "version_format": "patch"
+        "version_format": "minor"
     },
     "cosign": {
         "latest": {


### PR DESCRIPTION
We don't need to track the patch version, as we don't even have a README, and the README would specify the tag version.