### PR TITLE
No RMT-Server for TW

### DIFF
--- a/src/bci_build/package/rmt.py
+++ b/src/bci_build/package/rmt.py
@@ -49,5 +49,5 @@ COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 {DOCKERFILE_RUN} chmod +x /usr/local/bin/entrypoint.sh
 """,
     )
-    for os_version in ALL_NONBASE_OS_VERSIONS
+    for os_version in set(ALL_NONBASE_OS_VERSIONS) - {OsVersion.TUMBLEWEED}
 ]


### PR DESCRIPTION
RMT 3 only works with ruby 3.4, which has been dropped from TW, and RMT 2 only works with ruby 2.7, which also doesn't exist