### PR TITLE
No longer install openssl 1.1

### DIFF
--- a/src/bci_build/package/dotnet.py
+++ b/src/bci_build/package/dotnet.py
@@ -257,7 +257,11 @@ for os_version in (OsVersion.SP7,):
                 package_name=f"dotnet-{ver}",
                 exclusive_arch=_DOTNET_EXCLUSIVE_ARCH,
                 package_list=["libicu"]
-                + (["libopenssl1_1"] if os_version.is_sle15 else ["libopenssl3"])
+                + (
+                    ["libopenssl3", "coreutils"]
+                    if os_version.is_sle15
+                    else ["libopenssl3"]
+                )
                 + [*os_version.release_package_names],
                 third_party_repos=MS_REPOS,
                 third_party_package_list=[
@@ -297,7 +301,11 @@ for os_version in (OsVersion.SP7,):
                     [f"{ver}-{os_version.dist_id}"] if os_version.dist_id else []
                 ),
                 package_list=["libicu"]
-                + (["libopenssl1_1"] if os_version.is_sle15 else ["libopenssl3"])
+                + (
+                    ["libopenssl3", "coreutils"]
+                    if os_version.is_sle15
+                    else ["libopenssl3"]
+                )
                 + [*os_version.release_package_names],
                 third_party_repos=MS_REPOS,
                 third_party_package_list=[
@@ -331,7 +339,11 @@ for os_version in (OsVersion.SP7,):
                 ),
                 exclusive_arch=_DOTNET_EXCLUSIVE_ARCH,
                 package_list=["libicu"]
-                + (["libopenssl1_1"] if os_version.is_sle15 else ["libopenssl3"])
+                + (
+                    ["libopenssl3", "coreutils"]
+                    if os_version.is_sle15
+                    else ["libopenssl3"]
+                )
                 + [*os_version.release_package_names],
                 third_party_repos=MS_REPOS,
                 third_party_package_list=[


### PR DESCRIPTION
DotNet switched to openssl 3 a while ago. also avoid have-choice error in IBS on coreutils vs busybox-coreutils