### PR TITLE
Install FIPS compatibility on the SUSE Linux BCI application containers

### DIFF
--- a/src/bci_build/os_version.py
+++ b/src/bci_build/os_version.py
@@ -132,6 +132,15 @@ class OsVersion(enum.Enum):
         return sorted(list(r))
 
     @property
+    def fips_compatibility_packages(self) -> list[str]:
+        """Returns a list of packages to make the container FIPS ready"""
+        r = set()
+        if self.is_sl16:
+            r.add("patterns-base-fips")
+
+        return sorted(list(r))
+
+    @property
     def is_sle15(self) -> bool:
         return self.value in (
             OsVersion.SP4.value,

--- a/src/bci_build/package/nginx.py
+++ b/src/bci_build/package/nginx.py
@@ -52,7 +52,7 @@ def _get_nginx_kwargs(os_version: OsVersion):
                 parse_version=ParseVersion.MINOR,
             )
         ],
-        "package_list": (
+        "package_list": sorted(
             [
                 "curl",
                 "gawk",
@@ -62,8 +62,9 @@ def _get_nginx_kwargs(os_version: OsVersion):
                 "sed",
                 "grep",
             ]
-        )
-        + (["libcurl-mini4"] if os_version.is_sl16 else []),
+            + os_version.fips_compatibility_packages
+            + (["libcurl-mini4"] if os_version.is_sl16 else [])
+        ),
         "entrypoint": ["/usr/local/bin/docker-entrypoint.sh"],
         "from_target_image": generate_from_image_tag(os_version, "bci-micro"),
         "cmd": ["nginx", "-g", "daemon off;"],

--- a/src/bci_build/package/stunnel.py
+++ b/src/bci_build/package/stunnel.py
@@ -22,7 +22,7 @@ STUNNEL_CONTAINERS = [
         version=(stunnel_version_re := "%%stunnel_re%%"),
         is_singleton_image=True,
         pretty_name="Stunnel",
-        package_list=["stunnel"],
+        package_list=sorted(["stunnel"] + os_version.fips_compatibility_packages),
         support_level=SupportLevel.L3,
         replacements_via_service=[
             Replacement(stunnel_version_re, package_name="stunnel")

--- a/src/bci_build/package/three89_ds.py
+++ b/src/bci_build/package/three89_ds.py
@@ -40,6 +40,7 @@ THREE_EIGHT_NINE_DS_CONTAINERS = [
         package_list=sorted(
             ["389-ds", "timezone", "openssl", "nss_synth", "tar"]
             + (["aaa_base"] if os_version.is_sle15 else [])
+            + os_version.fips_compatibility_packages
         ),
         cmd=["/usr/lib/dirsrv/dscontainer", "-r"],
         version="%%389ds_version%%",

--- a/src/bci_build/package/valkey.py
+++ b/src/bci_build/package/valkey.py
@@ -44,7 +44,7 @@ VALKEY_CONTAINERS = [
             )
         ],
         license="BSD-3-Clause",
-        package_list=["valkey", "sed"],
+        package_list=sorted(["valkey", "sed"] + os_version.fips_compatibility_packages),
         entrypoint=["/usr/bin/valkey-server"],
         cmd=["/etc/valkey/valkey.conf"],
         entrypoint_user="valkey",


### PR DESCRIPTION
This is a core SLES feature, we cannot not ship it.