### PR TITLE
Filter base container pkgs from expansion for non-base containers

### DIFF
--- a/src/bci_build/templates.py
+++ b/src/bci_build/templates.py
@@ -42,6 +42,9 @@ DOCKERFILE_TEMPLATE = jinja2.Template(
 {%- if image.build_release %}
 #!BuildRelease: {{ image.build_release }}
 {%- endif %}
+{%- if image.from_target_image and not "scratch" in image.dockerfile_from_target_ref and not "bci-nano" in image.dockerfile_from_target_ref %}
+#!FilterBaseContainerPkgs
+{%- endif %}
 {{ image.dockerfile_from_line }}
 {%- if image.from_target_image %}
 COPY --from=target / /target

--- a/tests/test_build_recipe.py
+++ b/tests/test_build_recipe.py
@@ -650,6 +650,7 @@ def test_os_build_recipe_templates(kiwi_xml: str, image: OsContainer) -> None:
 #!BuildName: containers-test-42
 #!BuildVersion: %%emacs_version%%
 #!BuildRelease: 30
+#!FilterBaseContainerPkgs
 FROM registry.suse.com/bci/bci-micro:15.7 AS target
 FROM bci/bci-base:15.7 AS builder
 COPY --from=target / /target
@@ -717,6 +718,7 @@ LABEL io.artifacthub.package.readme-url="%SOURCEURL_WITH(README.md)%"
 #!BuildName: containers-git-42
 #!BuildVersion: %%git_version%%
 #!BuildRelease: 60
+#!FilterBaseContainerPkgs
 FROM registry.suse.com/bci/bci-micro:15.7 AS target
 FROM bci/bci-base:15.7 AS builder
 COPY --from=target / /target


### PR DESCRIPTION
This helps avoiding the double rebuilds we're getting due to building against released base containers.