### PR TITLE
nginx: allow to run with any user

### DIFF
--- a/src/bci_build/package/nginx.py
+++ b/src/bci_build/package/nginx.py
@@ -80,17 +80,24 @@ def _get_nginx_kwargs(os_version: OsVersion):
         ),
         "build_stage_custom_end": generate_package_version_check(
             "nginx", nginx_version, use_target=True
-        ),
+        )
+        + textwrap.dedent(f"""
+            {DOCKERFILE_RUN} mkdir /target/docker-entrypoint.d
+            COPY [1-4]0-*.sh /target/docker-entrypoint.d/
+            COPY docker-entrypoint.sh /target/usr/local/bin
+            COPY index.html /target/srv/www/htdocs/
+            {DOCKERFILE_RUN} chmod +x /target/docker-entrypoint.d/*.sh /target/usr/local/bin/docker-entrypoint.sh
+            {DOCKERFILE_RUN} \\
+                mkdir -p /target/tmp/nginx/client_body_temp \\
+                         /target/tmp/nginx/proxy_temp \\
+                         /target/tmp/nginx/fastcgi_temp \\
+                         /target/tmp/nginx/uwsgi_temp \\
+                         /target/tmp/nginx/scgi_temp; \\
+                chmod -R 777 /target/etc/nginx \\
+                             /target/var/log/nginx \\
+                             /target/tmp/nginx;"""),
         "custom_end": textwrap.dedent(f"""
-            {DOCKERFILE_RUN} mkdir /docker-entrypoint.d
-            COPY [1-4]0-*.sh /docker-entrypoint.d/
-            COPY docker-entrypoint.sh /usr/local/bin
-            COPY index.html /srv/www/htdocs/
-            {DOCKERFILE_RUN} chmod +x /docker-entrypoint.d/*.sh /usr/local/bin/docker-entrypoint.sh
-            {DOCKERFILE_RUN} set -euo pipefail; mkdir -p /var/cache/nginx /var/run/nginx /tmp/client_temp /tmp/proxy_temp /tmp/fastcgi_temp /tmp/uwsgi_temp /tmp/scgi_temp;\
-                ln -sf /dev/stdout /var/log/nginx/access.log;\
-                ln -sf /dev/stderr /var/log/nginx/error.log;\
-                chown -R nginx:nginx /var/cache/nginx /etc/nginx /var/run/nginx /var/log/nginx /tmp/client_temp /tmp/proxy_temp /tmp/fastcgi_temp /tmp/uwsgi_temp /tmp/scgi_temp;
+            {DOCKERFILE_RUN} ln -sf /dev/stdout /var/log/nginx/access.log; ln -sf /dev/stderr /var/log/nginx/error.log
             STOPSIGNAL SIGQUIT"""),
     }
 

--- a/src/bci_build/package/nginx/40-unprivileged-mode.sh
+++ b/src/bci_build/package/nginx/40-unprivileged-mode.sh
@@ -2,33 +2,56 @@
 
 set -e
 
+ME=$(basename "$0")
 CURRENT_UID=$(id -u)
+
 if [ "$CURRENT_UID" -gt "0" ]; then
-    echo "$0: Running as unprivileged user (UID: $CURRENT_UID). Configuring for unprivileged mode (Port 8080)."
+    echo "$ME: Running as unprivileged user (UID: $CURRENT_UID)."
 
     CONF_FILES="/etc/nginx/conf.d/default.conf /etc/nginx/nginx.conf"
 
     for FILE in $CONF_FILES; do
+        [ -f "$FILE" ] || continue
+
         if [ -w "$FILE" ]; then
-            if grep -q "listen .*80;" "$FILE"; then
-                echo "Changing port 80 to 8080 in $FILE"
-                sed 's/listen\s*80;/listen 8080;/g' "$FILE" > /tmp/client_temp/nginx_swap.conf && \
-                cat /tmp/client_temp/nginx_swap.conf > "$FILE" && \
-                rm -f /tmp/client_temp/nginx_swap.conf
+            if grep -E -q 'listen\s+80;' "$FILE"; then
+                sed -i 's/listen\s*80;/listen 8080;/g' "$FILE"
+                echo "$ME: NGINX port was updated from 80 to 8080!"
+            elif grep -q 'listen 8080;' "$FILE"; then
+                echo "$ME: NGINX port is already set to 8080. No changes needed."
+            else
+                echo "$ME: NGINX port was not updated. Failed to find listen parameter!"
             fi
 
             if [ "$FILE" = "/etc/nginx/nginx.conf" ]; then
-                echo "Redirecting NGINX temp paths and setting PID to /tmp in $FILE"
-                sed -e '/^user/d' \
-                    -e 's,^#\?\s*pid\s\+.*;$,pid /var/run/nginx/nginx.pid;,' \
-                    -e '/http {/a \    client_body_temp_path /tmp/client_temp;\n    proxy_temp_path /tmp/proxy_temp;\n    fastcgi_temp_path /tmp/fastcgi_temp;\n    uwsgi_temp_path /tmp/uwsgi_temp;\n    scgi_temp_path /tmp/scgi_temp;' \
-                    "$FILE" > /tmp/client_temp/nginx_ultra.conf && \
-                cat /tmp/client_temp/nginx_ultra.conf > "$FILE" && \
-                rm -f /tmp/client_temp/nginx_ultra.conf
-                echo "$0: Removed 'user' directive and updated PID path."
+                if grep -E -q '^user\b' "$FILE"; then
+                    sed -i -e '/^user/d' "$FILE"
+                    echo "$ME: Removed 'user' directive."
+                else
+                    echo "$ME: Skipping user modification. The 'user' directive was not found!"
+                fi
+
+                if grep -E -q '^#?\s*pid\s+' "$FILE"; then
+                    sed -i -e 's,^#\?\s*pid\s\+.*;$,pid /tmp/nginx/nginx.pid;,' "$FILE"
+                    echo "$ME: Updated PID path to '/tmp/nginx/nginx.pid'."
+                else
+                    echo "$ME: Skipping PID modification. pid directive not found!"
+                fi
+
+                required="client_body_temp_path proxy_temp_path fastcgi_temp_path uwsgi_temp_path scgi_temp_path"
+
+                for directive in $required; do
+                    if grep -Eq "^[[:space:]]*${directive}[[:space:]]+" "$FILE"; then
+                        echo "$ME: Skipping ${directive} modification. Already set."
+                    else
+                        sed -i "/http {/a\    ${directive} /tmp/${directive%_path};" "$FILE"
+                        echo "$ME: Redirected ${directive} to '/tmp/${directive%_path}'."
+                    fi
+                done
             fi
+        else
+            echo "$ME: Permission denied for user $CURRENT_UID: $FILE"
+            exit 1
         fi
     done
-
-    echo "$0: Listening on port 8080."
 fi


### PR DESCRIPTION
Make 40-unprivileged-mode.sh more explicit on what is doing and double check before making any changes.

Change most nginx paths to /tmp/nginx and chmod it to 777 to give permission to any user, even the ones that do not exist in the image.