### PR TITLE
python: always install python3-base

### DIFF
--- a/src/bci_build/package/python.py
+++ b/src/bci_build/package/python.py
@@ -90,6 +90,7 @@ def _get_python_kwargs(
     if build_flavor != "micro":
         package_list = (
             *package_list,
+            f"{py3}-base",
             f"{py3}-devel",
             *os_version.common_devel_packages,
             *([f"{py3}-wheel"] if has_wheel else []),


### PR DESCRIPTION
Otherwise /usr/bin/python3 is not provided by any packages.