### PR TITLE
Restore world-readable rpmdb after the reproducibility rebuild

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -55,9 +55,12 @@ LOG_CLEAN: str = textwrap.dedent("""rm -rf {/target,}/var/log/{alternatives.log,
     rm -f {/target,}/var/cache/ldconfig/aux-cache
 """)
 
-#: Rebuild the rpm database to make it reproducible
+#: Rebuild the rpm database to make it reproducible. The rebuilt Packages.db
+#: comes back mode 0600 (created inside the private mktemp dir); restore the
+#: stock 0644 so rpm keeps working for non-root users of the image.
 TARGET_REBUILDDB: str = """t=$(mktemp -d); mv /target/usr/lib/sysimage/rpm/Packages.db $t; rpmdb --rebuilddb --dbpath=$t; \\
-    rm /target/usr/lib/sysimage/rpm/*.db && mv $t/Packages.db /target/usr/lib/sysimage/rpm/"""
+    rm /target/usr/lib/sysimage/rpm/*.db && mv $t/Packages.db /target/usr/lib/sysimage/rpm/ && \\
+    chmod 0644 /target/usr/lib/sysimage/rpm/Packages.db"""
 
 #: The string to use as a placeholder for the build source services to put in the release number
 _RELEASE_PLACEHOLDER = "%RELEASE%"


### PR DESCRIPTION
Caught by the BCI test suite on the kubevirt libguestfs-tools image, where it also masqueraded as a compat-usrmerge-tools removal failure - the package is absent, but the test could not read the rpm database to see it.

