### PR TITLE
bot: Fix 16.1 project meta

### DIFF
--- a/src/staging/project_setup.py
+++ b/src/staging/project_setup.py
@@ -157,10 +157,9 @@ def generate_meta(
             assert os_version.is_sl16
             first_prj = f"SUSE:SLFO:Products:SLES:{os_version}"
             last_prj = "SUSE:SLFO:Main"
-            if os_version in (OsVersion.SL16_0,):
-                first_prj = "SUSE:Registry"
             match os_version:
                 case OsVersion.SL16_0 | OsVersion.SL16_1:
+                    first_prj = "SUSE:Registry"
                     last_prj = f"SUSE:SLFO:Products:SLES:{os_version}"
                 case OsVersion.SL16_2:
                     last_prj = "SUSE:SLFO:Main"

--- a/tests/test_project_setup.py
+++ b/tests/test_project_setup.py
@@ -243,7 +243,7 @@ This project is automatically updated from git. Please do **not** send submit re
     <enable/>
   </debuginfo>
   <repository name="standard">
-    <path project="SUSE:SLFO:Products:SLES:16.1" repository="standard"/>
+    <path project="SUSE:Registry" repository="standard"/>
     <path project="devel:BCI:16.1" repository="containerfile"/>
     <path project="devel:BCI:16.1" repository="containerkiwi"/>
     <path project="devel:BCI:16.1" repository="standard"/>


### PR DESCRIPTION
A duplicated key causes a 400 error when updating the project meta.