### PR TITLE
Remove golang-openssl from SLFO

### DIFF
--- a/src/bci_build/package/golang.py
+++ b/src/bci_build/package/golang.py
@@ -135,7 +135,7 @@ GOLANG_CONTAINERS = (
         for ver, govariant, os_version in product(
             _GOLANG_OPENSSL_VERSIONS,
             ("-openssl",),
-            (OsVersion.SP7, OsVersion.SL16_0, OsVersion.SL16_1),
+            (OsVersion.SP7,),
         )
     ]
     + [


### PR DESCRIPTION
We'll stop providing it with go 1.27 onwards, and 1.25/1.26 are currently published from SLE15