### PR TITLE
Workaround rpmdb --rebuild-db --dbpath=<path> setting incorrect permi…

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -57,7 +57,7 @@ LOG_CLEAN: str = textwrap.dedent("""rm -rf {/target,}/var/log/{alternatives.log,
 
 #: Rebuild the rpm database to make it reproducible
 TARGET_REBUILDDB: str = """t=$(mktemp -d); mv /target/usr/lib/sysimage/rpm/Packages.db $t; rpmdb --rebuilddb --dbpath=$t; \\
-    rm /target/usr/lib/sysimage/rpm/*.db && mv $t/Packages.db /target/usr/lib/sysimage/rpm/"""
+    rm /target/usr/lib/sysimage/rpm/*.db && install -m 0644 $t/Packages.db /target/usr/lib/sysimage/rpm/"""
 
 #: The string to use as a placeholder for the build source services to put in the release number
 _RELEASE_PLACEHOLDER = "%RELEASE%"


### PR DESCRIPTION
…ssions

running rebuilddb on a nondefault path sets the permissions to 0600, but we need 0644