### PR TITLE
feat: add opencode sandbox

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -1514,6 +1514,7 @@ from .nano import NANO_CONTAINERS  # noqa: E402
 from .nginx import NGINX_CONTAINERS  # noqa: E402
 from .node import NODE_CONTAINERS  # noqa: E402
 from .nvidia import NVIDIA_CONTAINERS  # noqa: E402
+from .opencode import OPENCODE_CONTAINERS  # noqa: E402
 from .openjdk import OPENJDK_CONTAINERS  # noqa: E402
 from .php import PHP_CONTAINERS  # noqa: E402
 from .postfix import POSTFIX_CONTAINERS  # noqa: E402
@@ -1562,6 +1563,7 @@ ALL_CONTAINER_IMAGE_NAMES: dict[str, BaseContainerImage] = {
         *RMT_CONTAINERS,
         *RUST_CONTAINERS,
         *GEMINI_CONTAINERS,
+        *OPENCODE_CONTAINERS,
         *GIT_CONTAINERS,
         *GOLANG_CONTAINERS,
         *KIWI_CONTAINERS,

--- a/src/bci_build/package/opencode.py
+++ b/src/bci_build/package/opencode.py
@@ -1,0 +1,94 @@
+"""Opencode BCI container"""
+
+import textwrap
+from typing import Any
+
+from bci_build.container_attributes import Arch
+from bci_build.container_attributes import SupportLevel
+from bci_build.containercrate import ContainerCrate
+from bci_build.os_version import OsVersion
+from bci_build.package import DOCKERFILE_RUN
+from bci_build.package import ApplicationStackContainer
+from bci_build.package import DevelopmentContainer
+from bci_build.package.helpers import generate_from_image_tag
+from bci_build.replacement import Replacement
+from bci_build.util import ParseVersion
+
+
+def _common_args() -> dict[str, Any]:
+    return {
+        "name": "opencode",
+        "package_name": "opencode-image",
+        "version": (opencode_ver := "%%opencode_version%%"),
+        "is_singleton_image": True,
+        "use_build_flavor_in_tag": False,
+        "no_recommends": False,
+        "os_version": OsVersion.TUMBLEWEED,
+        "is_latest": True,
+        "support_level": SupportLevel.UNSUPPORTED,
+        "replacements_via_service": [
+            Replacement(
+                regex_in_build_description=opencode_ver,
+                package_name="opencode",
+                parse_version=ParseVersion.PATCH,
+            )
+        ],
+        "custom_end": "WORKDIR /workspace/\n",
+        "extra_labels": {
+            "run": textwrap.dedent("""\
+                podman run --rm -it \\
+                --userns=keep-id:uid=1000 \\
+                -v \\${HOME}/.cache/opencode:/home/sandbox/.cache/opencode:Z \\
+                -v \\${HOME}/.config/opencode:/home/sandbox/.config/opencode:Z \\
+                -v \\${HOME}/.local/share/opencode:/home/sandbox/.local/share/opencode:Z \\
+                -v \\$PWD:/workspace:Z \\
+                \\${IMAGE}"""),
+        },
+        "entrypoint": ["/usr/bin/opencode"],
+        "entrypoint_user": "sandbox",
+        "volumes": ["/workspace/"],
+        "exclusive_arch": [Arch.X86_64, Arch.AARCH64],
+    }
+
+
+OPENCODE_CONTAINERS = [
+    ApplicationStackContainer(
+        **_common_args(),
+        build_flavor="base",
+        pretty_name="Opencode sandbox",
+        tag_version="base",
+        from_target_image=generate_from_image_tag(OsVersion.TUMBLEWEED, "bci-micro"),
+        package_list=[
+            "aaa_base",
+            "findutils",
+            "gawk",
+            "grep",
+            "less",
+            "opencode",
+            "sed",
+            "xz",
+        ],
+        build_stage_custom_end=textwrap.dedent(f"""\
+            {DOCKERFILE_RUN} useradd -R /target/ -mUK HOME_MODE=0700 -u 1000 sandbox; \\
+                cp -r /target/usr/etc/skel/. /target/home/sandbox/; \\
+                chroot /target/ chown -R sandbox:sandbox /home/sandbox/; \\
+                chroot /target/ install -dm 0700 -o sandbox -g sandbox /workspace/"""),
+    ),
+    DevelopmentContainer(
+        **_common_args(),
+        build_flavor="devel",
+        pretty_name="Opencode development sandbox",
+        tag_version="devel",
+        package_list=[
+            "findutils",
+            "gawk",
+            "less",
+            "opencode",
+        ],
+        build_stage_custom_end=textwrap.dedent(f"""\
+            {DOCKERFILE_RUN} useradd -u 1000 sandbox; \\
+                install -dm 0700 -o sandbox -g sandbox /workspace/"""),
+    ),
+]
+
+OPENCODE_CRATE = ContainerCrate(OPENCODE_CONTAINERS)

--- a/src/bci_build/package/opencode/README.md.j2
+++ b/src/bci_build/package/opencode/README.md.j2
@@ -1,0 +1,47 @@
+# The {{ image.title }} container image
+
+{% include 'badges.j2' %}
+
+## Description
+
+This image provides a sandbox for [Opencode](https://opencode.ai), running as a
+non-root `sandbox` user (uid `1000`). Use `/workspace` as the volume mount point
+for files that AI should have access to.
+
+The image is published in two flavors:
+
+| Flavor  | Description                                                      |
+| ------- | ---------------------------------------------------------------- |
+| `base`  | The hardened runtime image, with `opencode` and basic tools.     |
+| `devel` | The development image, that can be extended with source tooling. |
+
+Some features are disabled by default.
+See [disabled features](#disabled-features) section.
+
+## Usage
+
+To start opencode and give AI access to files in current directory use:
+
+```Shell
+podman run --rm -it \
+    --userns=keep-id:uid=1000 \
+    -v $HOME/.cache/opencode:/home/sandbox/.cache/opencode:Z \
+    -v $HOME/.config/opencode:/home/sandbox/.config/opencode:Z \
+    -v $HOME/.local/share/opencode:/home/sandbox/.local/share/opencode:Z \
+    -v $PWD:/workspace:Z \
+    {{ image.pretty_reference }}
+```
+
+## Disabled features
+
+Syntax highlighting, formatters, LSP integrations, provider SDKs and self update
+are disabled out of the box. To enable desired features set environment
+variables outlined below:
+
+- `OPENCODE_ALLOW_GRAMMAR_DOWNLOAD=1` - Allow opencode to download grammar files
+  (language definitions used for syntax highlighting and templating).
+- `OPENCODE_ALLOW_NPM_INSTALL=1` - Allow the installation of formatters,
+  LSP integrations and provider SDKs using npm.
+- `OPENCODE_ENABLE_AUTOUPDATE=1` - Enable opencode's automatic update checker.
+
+{% include 'licensing_and_eula.j2' %}


### PR DESCRIPTION
Add opencode sandbox image in two flavors:
  base - hardened image containing just opencode and basic tools.
  devel - tumbleweed based development image.