### PR TITLE
Disable Sbom filelists for kernel container

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -287,6 +287,9 @@ class BaseContainerImage(abc.ABC):
     #: present
     logo_url: str = ""
 
+    #: Set OBS flag to disable filelist generation in SBOMs to avoid upload limits
+    obs_disable_sbom_filelists: bool = False
+
     #: Optional release counter that will be used in ``#!BuildRelease``
     #: magic comment to ensure that versions are sequentially increasing.
     #: In cases where containers switch the base OS the counter resets and

--- a/src/bci_build/package/basecontainers.py
+++ b/src/bci_build/package/basecontainers.py
@@ -468,6 +468,7 @@ for os_version in set(ALL_BASE_OS_VERSIONS) - {OsVersion.TUMBLEWEED}:
                 OsVersion.SL16_0: 17,
             },
             supported_until=_SUPPORTED_UNTIL_SLE.get(os_version),
+            obs_disable_sbom_filelists=True,
             is_latest=os_version in CAN_BE_LATEST_BASE_OS_VERSION,
             package_list=(
                 [

--- a/src/bci_build/templates.py
+++ b/src/bci_build/templates.py
@@ -28,6 +28,9 @@ DOCKERFILE_TEMPLATE = jinja2.Template(
 {{ INFOHEADER }}
 
 #!UseOBSRepositories
+{%- if image.obs_disable_sbom_filelists %}
+#!SbomNoFilesGeneration
+{%- endif %}
 {% if image.exclusive_arch %}#!ExclusiveArch: {% for arch in image.exclusive_arch %}{{ arch }}{{ " " if not loop.last }}{% endfor %}{%- endif %}
 {% for tag in image.build_tags -%}
 #!BuildTag: {{ tag }}


### PR DESCRIPTION
Especially on aarch64, where we install kernel-default-devel and kernel-64kb-devel, we have a lot of files and that exceeds some uploading limit for the rekor transparency log.