### PR TITLE
fix: remove /dev/null

### DIFF
--- a/src/bci_build/package/__init__.py
+++ b/src/bci_build/package/__init__.py
@@ -52,7 +52,8 @@ LOG_CLEAN: str = textwrap.dedent("""rm -rf {/target,}/var/log/{alternatives.log,
     rm -f {/target,}/usr/lib/sysimage/rpm/.rpm.lock; \\
     rm -f {/target,}/var/lib/zypp/AnonymousUniqueId; \\
     rm -f {/target,}/var/lib/zypp/AutoInstalled; \\
-    rm -f {/target,}/var/cache/ldconfig/aux-cache
+    rm -f {/target,}/var/cache/ldconfig/aux-cache \\
+    rm -f {/target,}/dev/null
 """)
 
 #: Rebuild the rpm database to make it reproducible


### PR DESCRIPTION
A few images ship /dev/null, and if a command pipes to /dev/null, the file can differ between builds.