### PR TITLE
kubevirt: make /etc/libvirt/hooks usable by the 1.9 launcher

### DIFF
--- a/src/bci_build/package/kubevirt.py
+++ b/src/bci_build/package/kubevirt.py
@@ -56,6 +56,27 @@ def _kubevirt_dir(kubevirt_version: str) -> str:
     return f"kube-virt-{kubevirt_version}"
 
 
+def _libvirt_hooks_dir(kubevirt_version: str) -> str:
+    """Create /etc/libvirt/hooks for the 1.9 launcher (bsc#1272604).
+
+    virt-launcher symlinks its qemu hook there on start-up as uid 107 and
+    panics if it cannot. libvirt >= 12.6 ships the directory only in
+    libvirt-daemon-hooks, which this image does not install, so it is missing
+    on Tumbleweed; on SLE 16.0 (libvirt 11.4) it exists but is root-only.
+    Only 1.9 symlinks at run time: 1.8 keeps the gate off and 1.10 ships the
+    binary at the hook path instead.
+    """
+    version = tuple(int(part) for part in kubevirt_version.split("."))
+    if not (1, 9) <= version < (1, 10):
+        return ""
+    # Whole lines, indented like the block they land in: the caller dedents the
+    # rendered string, so a flush-left snippet would flatten it.
+    return (
+        "                # virt-launcher needs this to exist and be writable by 107\n"
+        f"                {DOCKERFILE_RUN} install -d -m 0755 -o 107 -g 107 /etc/libvirt/hooks"
+    )
+
+
 def _get_kubevirt_kwargs(
     service: str,
     kubevirt_version: str,
@@ -293,6 +314,7 @@ KUBEVIRT_CONTAINERS = (
                     install -m 0644 /usr/share/{_kubevirt_dir(kubevirt_version)}/virt-launcher/qemu.conf /etc/libvirt/qemu.conf && \\
                     chmod 0755 /etc/libvirt && \\
                     setcap 'cap_net_bind_service=+ep' /usr/bin/virt-launcher-monitor
+{_libvirt_hooks_dir(kubevirt_version)}
                 # virt-launcher probes the firmware under the paths KubeVirt
                 # hardcodes per architecture, see:
                 # https://github.com/kubevirt/kubevirt/blob/v1.8.0/pkg/virt-config/virt-config.go


### PR DESCRIPTION
KubeVirt 1.9's virt-launcher symlinks its qemu hook into /etc/libvirt/hooks when it starts and panics when it cannot:

  panic: failed to create symlink for qemu hook: symlink
  /usr/bin/libvirt-hook-client /etc/libvirt/hooks/qemu:
  no such file or directory

Every VMI runs as uid 107 (the mutating webhook sets Status.RuntimeUser unconditionally) and the compute container holds only CAP_NET_BIND_SERVICE, so the directory must exist AND be writable by
107. A root-owned directory is not enough. Both distributions we build for fail, for different reasons:

  openSUSE/Tumbleweed (libvirt >= 12.6) moved the directory into
  libvirt-daemon-hooks, which the lean launcher image cannot install --
  its %post fails in a container build and it ships a qemu hook that
  would collide with the symlink -- so the directory is absent.

  SLE 16.0 (libvirt 11.4) still has it in libvirt-daemon-common, but as
  drwx------ root:root, which uid 107 cannot write to.

`install -d` covers both: it creates the directory on Tumbleweed and re-owns the existing one on 16.0. Verified in both images -- as uid 107 the symlink fails with EACCES without it and succeeds with it.

Scoped to 1.9 rather than applied to every KubeVirt image. 1.8 keeps the LibvirtHooksServerAndClient gate Alpha (off) and never symlinks, so its image is unchanged. 1.10 removes the runtime symlink altogether -- kubevirt/kubevirt#18687 installs the hook binary at /etc/libvirt/hooks/qemu with owner 107.107 at image build time -- so the helper returns nothing there too and this disappears on its own. The version test compares integer tuples, not strings, so 1.10 does not sort below 1.9.

Reported downstream as bsc#1272604.